### PR TITLE
Deploy via central publishing and update readme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,14 +34,24 @@ jobs:
 
     - name: Verify with Maven
       if: github.event_name == 'pull_request'
-      run: mvn -B clean verify
+      run: mvn -B -Prelease clean verify 
 
-    - name: Build with Maven
-      run: mvn -B compile --file pom.xml
+    - name: Verify javadoc
+      if: github.event_name == 'pull_request'
+      run: mvn -B -Prelease javadoc:test-javadoc
+
+    - name: Compile
+      run: mvn -B -Prelease compile
+
+    - name: Javadoc
+      run: mvn -B -Prelease javadoc:jar
+
+    - name: Source
+      run: mvn -B -Prelease source:jar
 
     - name: Publish to Apache Maven Central
       if: github.ref == 'refs/heads/main' && github.event_name == 'push' 
-      run: mvn -X -Pbuild-extras,release deploy
+      run: mvn -B -Prelease deploy
       env:
         OSSRH_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Verify with Maven
       if: github.event_name == 'pull_request'
-      run: mvn -B -Prelease clean verify 
+      run: mvn -B clean verify 
 
     - name: Verify javadoc
       if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
-# projectmanager-sdk-java
-ProjectManager.com SDK for Java
+[![Maven Central](https://img.shields.io/maven-central/v/com.projectmanager/projectmanagersdk?style=plastic)](https://central.sonatype.com/artifact/com.projectmanager/projectmanagersdk)
+
+# ProjectManager.com SDK for API v4
+
+This software development kit contains all API definitions for the [ProjectManager.com](https://www.projectmanager.com) REST API v4.  
+
+# Why use the SDK?
+
+The ProjectManager API v4 is available as a REST definition in OpenAPI format.  You can read the documentation online at [developer.projectmanager.com](https://developer.projectmanager.com/).
+
+This SDK provides a few capabilities that developers may find more useful than hand-writing REST API code:
+* Documentation is available in your editor via autocomplete and hover docblocks
+* Patch notes are available detailing changes
+* Automated updates whenever new API endpoints are added
+
+# Using this SDK
+
+Here's how to add this SDK to create a project.  
+
+First, you must add a reference in your `pom.xml` file.  Check [the SonaType central page](https://central.sonatype.com/artifact/com.projectmanager/projectmanagersdk/overview) for the latest version number:
+
+```xml
+<dependency>
+    <groupId>com.projectmanager</groupId>
+    <artifactId>projectmanagersdk</artifactId>
+    <version>97.0.2178</version>
+</dependency>
+```
+
+Next, run `mvn install`.
+
+To create an API client for ProjectManager within Java, you must specify:
+* Your API key, and
+* Your environment URL.
+
+For the ProjectManager production environment, the environment URL is `https://api.projectmanager.com`.
+
+To [obtain a ProjectManager.com API key](https://developer.projectmanager.com/reference/api-keys):
+* Log on to ProjectManager.com
+* Click your name in the bottom left hand corner
+* Select Account, then API
+* Follow the instructions on the page to create a new API key
+
+```java
+import com.projectmanager.ProjectManagerClient;
+
+public class JavaExample
+{
+    public static ProjectManagerClient GetProjectManagerClient(String apiKey, String env)
+    {
+        return ProjectManagerClient
+            .withEnvironment(env)
+            .withBearerToken(apiKey)
+            .WithAppName("MyApplicationName");
+    }
+}
+```
+
+        
+        
+        

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,26 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -106,36 +122,6 @@
                                 <arg>loopback</arg>
                             </gpgArguments>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>build-extras</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <name>ProjectManagerSDK</name>
     <description>Software development kit for the ProjectManager.com API. for Java</description>
-    <url></url>
+    <url>https://developer.projectmanager.com/</url>
 
     <licenses>
         <license>
@@ -61,33 +61,21 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>release</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.1.2</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenEnabled>true</tokenEnabled>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Looks like the new documentation SonaType sent me worked:

https://central.sonatype.org/publish-ea/publish-ea-guide/

Much better.