### PR TITLE
Release 104

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.projectmanager</groupId>
     <artifactId>projectmanagersdk</artifactId>
-    <version>103.0.3003</version>
+    <version>104.0.3086</version>
 
     <name>ProjectManagerSDK</name>
     <description>Software development kit for the ProjectManager.com API. for Java</description>

--- a/src/main/java/com/projectmanager/BlobRequest.java
+++ b/src/main/java/com/projectmanager/BlobRequest.java
@@ -148,7 +148,7 @@ public class BlobRequest {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "103.0.3003.0");
+            request.addHeader("SdkVersion", "104.0.3086.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/ProjectManagerClient.java
+++ b/src/main/java/com/projectmanager/ProjectManagerClient.java
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    103.0.3003
+ * @version    104.0.3086
  * @link       https://github.com/projectmgr/projectmanager-sdk-java
  */
 

--- a/src/main/java/com/projectmanager/RestRequest.java
+++ b/src/main/java/com/projectmanager/RestRequest.java
@@ -148,7 +148,7 @@ public class RestRequest<@NotNull T> {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "103.0.3003.0");
+            request.addHeader("SdkVersion", "104.0.3086.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/clients/ChangesetClient.java
+++ b/src/main/java/com/projectmanager/clients/ChangesetClient.java
@@ -22,9 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import com.google.gson.reflect.TypeToken;
 import com.projectmanager.AstroResult;
-import com.projectmanager.models.ChangesetGetResponseDto;
+import com.projectmanager.models.ProjectChangeStatusDto;
 
-import com.projectmanager.models.ChangeSetResponseDto;
+import com.projectmanager.models.ProjectChangeDto;
 
 /**
  * Contains all methods related to Changeset
@@ -53,11 +53,11 @@ public class ChangesetClient
      * @param changeSetId The unique ID number of the Changeset to retrieve
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
-    public @NotNull AstroResult<ChangesetGetResponseDto> retrieveChangeset(@NotNull String changeSetId)
+    public @NotNull AstroResult<ProjectChangeStatusDto> retrieveChangesetstatus(@NotNull String changeSetId)
     {
-        RestRequest<ChangesetGetResponseDto> r = new RestRequest<ChangesetGetResponseDto>(this.client, "GET", "/api/data/changesets/{changeSetId}");
+        RestRequest<ProjectChangeStatusDto> r = new RestRequest<ProjectChangeStatusDto>(this.client, "GET", "/api/data/changesets/{changeSetId}");
         r.AddPath("{changeSetId}", changeSetId == null ? "" : changeSetId.toString());
-        return r.Call(new TypeToken<AstroResult<ChangesetGetResponseDto>>() {}.getType());
+        return r.Call(new TypeToken<AstroResult<ProjectChangeStatusDto>>() {}.getType());
     }
 
     /**
@@ -72,15 +72,15 @@ public class ChangesetClient
      * @param changeSetId The unique ID number of the Changeset to retrieve
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
-    public @NotNull AstroResult<ChangesetGetResponseDto> retrieveCompletedChangeset(@NotNull String changeSetId)
+    public @NotNull AstroResult<ProjectChangeStatusDto> retrieveCompletedChangesetstatus(@NotNull String changeSetId)
     {
-        RestRequest<ChangesetGetResponseDto> r = new RestRequest<ChangesetGetResponseDto>(this.client, "GET", "/api/data/changesets/{changeSetId}/poll");
+        RestRequest<ProjectChangeStatusDto> r = new RestRequest<ProjectChangeStatusDto>(this.client, "GET", "/api/data/changesets/{changeSetId}/poll");
         r.AddPath("{changeSetId}", changeSetId == null ? "" : changeSetId.toString());
-        return r.Call(new TypeToken<AstroResult<ChangesetGetResponseDto>>() {}.getType());
+        return r.Call(new TypeToken<AstroResult<ProjectChangeStatusDto>>() {}.getType());
     }
 
     /**
-     * Retrieve Changesets by Project ID
+     * Retrieve specific Project Changes by Project ID
      *
      * @param projectId Documentation pending
      * @param version Documentation pending
@@ -88,13 +88,13 @@ public class ChangesetClient
      * @param take Documentation pending
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
-    public @NotNull AstroResult<ChangeSetResponseDto[]> retrieveChangesetsbyprojectID(@NotNull String projectId, @Nullable Integer version, @Nullable Integer page, @Nullable Integer take)
+    public @NotNull AstroResult<ProjectChangeDto[]> retrieveProjectChangesbyprojectID(@NotNull String projectId, @Nullable Integer version, @Nullable Integer page, @Nullable Integer take)
     {
-        RestRequest<ChangeSetResponseDto[]> r = new RestRequest<ChangeSetResponseDto[]>(this.client, "GET", "/api/data/projects/{projectId}/changesets");
+        RestRequest<ProjectChangeDto[]> r = new RestRequest<ProjectChangeDto[]>(this.client, "GET", "/api/data/projects/{projectId}/changes");
         r.AddPath("{projectId}", projectId == null ? "" : projectId.toString());
         if (version != null) { r.AddQuery("version", version.toString()); }
         if (page != null) { r.AddQuery("page", page.toString()); }
         if (take != null) { r.AddQuery("take", take.toString()); }
-        return r.Call(new TypeToken<AstroResult<ChangeSetResponseDto[]>>() {}.getType());
+        return r.Call(new TypeToken<AstroResult<ProjectChangeDto[]>>() {}.getType());
     }
 }

--- a/src/main/java/com/projectmanager/models/ChangeSetDto.java
+++ b/src/main/java/com/projectmanager/models/ChangeSetDto.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * The project task change set
  */
-public class ChangeSetResponseDto
+public class ChangeSetDto
 {
     private @NotNull Integer projectChangeSetId;
     private @NotNull String id;

--- a/src/main/java/com/projectmanager/models/ProjectChangeDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectChangeDto.java
@@ -1,0 +1,144 @@
+
+/**
+ * ProjectManager API for Java
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-java
+ */
+
+
+package com.projectmanager.models;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The specific change action made against a project
+ */
+public class ProjectChangeDto
+{
+    private @NotNull String id;
+    private @NotNull String businessId;
+    private @NotNull String projectId;
+    private @NotNull Integer version;
+    private @NotNull String createBy;
+    private @NotNull String createDate;
+    private @Nullable String processDate;
+    private @NotNull Integer status;
+    private @Nullable Object changeData;
+
+    /**
+     * Project Change ID
+     *
+     * @return The field id
+     */
+    public @NotNull String getId() { return this.id; }
+    /**
+     * Project Change ID
+     *
+     * @param value The new value for id
+     */
+    public void setId(@NotNull String value) { this.id = value; }
+    /**
+     * Workspace ID
+     *
+     * @return The field businessId
+     */
+    public @NotNull String getBusinessId() { return this.businessId; }
+    /**
+     * Workspace ID
+     *
+     * @param value The new value for businessId
+     */
+    public void setBusinessId(@NotNull String value) { this.businessId = value; }
+    /**
+     * Project ID
+     *
+     * @return The field projectId
+     */
+    public @NotNull String getProjectId() { return this.projectId; }
+    /**
+     * Project ID
+     *
+     * @param value The new value for projectId
+     */
+    public void setProjectId(@NotNull String value) { this.projectId = value; }
+    /**
+     * Version of this Project Change
+     *
+     * @return The field version
+     */
+    public @NotNull Integer getVersion() { return this.version; }
+    /**
+     * Version of this Project Change
+     *
+     * @param value The new value for version
+     */
+    public void setVersion(@NotNull Integer value) { this.version = value; }
+    /**
+     * Created by GUID
+     *
+     * @return The field createBy
+     */
+    public @NotNull String getCreateBy() { return this.createBy; }
+    /**
+     * Created by GUID
+     *
+     * @param value The new value for createBy
+     */
+    public void setCreateBy(@NotNull String value) { this.createBy = value; }
+    /**
+     * Created date
+     *
+     * @return The field createDate
+     */
+    public @NotNull String getCreateDate() { return this.createDate; }
+    /**
+     * Created date
+     *
+     * @param value The new value for createDate
+     */
+    public void setCreateDate(@NotNull String value) { this.createDate = value; }
+    /**
+     * Processed date
+     *
+     * @return The field processDate
+     */
+    public @Nullable String getProcessDate() { return this.processDate; }
+    /**
+     * Processed date
+     *
+     * @param value The new value for processDate
+     */
+    public void setProcessDate(@Nullable String value) { this.processDate = value; }
+    /**
+     * The status of the Project Change
+     *
+     * @return The field status
+     */
+    public @NotNull Integer getStatus() { return this.status; }
+    /**
+     * The status of the Project Change
+     *
+     * @param value The new value for status
+     */
+    public void setStatus(@NotNull Integer value) { this.status = value; }
+    /**
+     * Project Change as JSON data
+     *
+     * @return The field changeData
+     */
+    public @Nullable Object getChangeData() { return this.changeData; }
+    /**
+     * Project Change as JSON data
+     *
+     * @param value The new value for changeData
+     */
+    public void setChangeData(@Nullable Object value) { this.changeData = value; }
+};

--- a/src/main/java/com/projectmanager/models/ProjectChangeStatusDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectChangeStatusDto.java
@@ -19,51 +19,51 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A Changeset is an individual edit that has been made to a project.  Since multiple users can
- * edit a project at the same time, individual Changesets are applied in a sequential fashion. If
- * a Changeset causes a conflict or cannot be applied, it will be rejected.  You can examine a
- * Changeset to determine its conflict resolution status.
+ * A ProjectChange is an individual edit that has been made to a project.  Since multiple users
+ * can edit a project at the same time, individual ProjectChanges are applied in a sequential
+ * fashion. If a ProjectChange causes a conflict or cannot be applied, it will be rejected.
+ * You can examine a ProjectChange to determine its conflict resolution status.
  */
-public class ChangesetGetResponseDto
+public class ProjectChangeStatusDto
 {
     private @NotNull String id;
     private @Nullable Boolean success;
     private @NotNull String state;
 
     /**
-     * The unique identifier of this Changeset.
+     * The unique identifier of this ProjectChange.
      *
      * @return The field id
      */
     public @NotNull String getId() { return this.id; }
     /**
-     * The unique identifier of this Changeset.
+     * The unique identifier of this ProjectChange.
      *
      * @param value The new value for id
      */
     public void setId(@NotNull String value) { this.id = value; }
     /**
-     * True if this Changeset was successfully applied.  If the Changeset has not been applied,
-     * this value is null.
+     * True if this ProjectChange was successfully applied.  If the ProjectChange has not been
+     * applied, this value is null.
      *
      * @return The field success
      */
     public @Nullable Boolean getSuccess() { return this.success; }
     /**
-     * True if this Changeset was successfully applied.  If the Changeset has not been applied,
-     * this value is null.
+     * True if this ProjectChange was successfully applied.  If the ProjectChange has not been
+     * applied, this value is null.
      *
      * @param value The new value for success
      */
     public void setSuccess(@Nullable Boolean value) { this.success = value; }
     /**
-     * A status flag that indicates the progress of the Changeset through resolution.
+     * A status flag that indicates the progress of the ProjectChange through resolution.
      *
      * @return The field state
      */
     public @NotNull String getState() { return this.state; }
     /**
-     * A status flag that indicates the progress of the Changeset through resolution.
+     * A status flag that indicates the progress of the ProjectChange through resolution.
      *
      * @param value The new value for state
      */


### PR DESCRIPTION
# Patch notes for 104.0.3086

These patch notes summarize the changes from version 103.0.3003.

Added 1 new APIs:
* Changeset.RetrieveProjectChangesByProjectID (GET /api/data/projects/{projectId}/changes)

Renamed 2 old APIs:
* Renamed 'Changeset.RetrieveChangeset' to 'Changeset.RetrieveChangesetStatus'
* Renamed 'Changeset.RetrieveCompletedChangeset' to 'Changeset.RetrieveCompletedChangesetStatus'

Deprecated 1 old APIs:
* TaskMetadata.GetTaskMetadata