### PR TITLE
Release 119

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.projectmanager</groupId>
     <artifactId>projectmanagersdk</artifactId>
-    <version>117.0.4438</version>
+    <version>119.0.4625</version>
 
     <name>ProjectManagerSDK</name>
     <description>Software development kit for the ProjectManager.com API. for Java</description>
@@ -33,11 +33,6 @@
         </developer>
     </developers>
 
-    <!-- replace with your data -->
-    <issueManagement>
-        <system>github</system>
-        <url>https://github.com/projectmgr/projectmanager-sdk-java/issues</url>
-    </issueManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -66,63 +61,47 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.12.1</version>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
             </plugin>
         </plugins>
     </build>
-
     <profiles>
         <profile>
-            <!-- required, used in .github/workflows/sonatype-publish.yml -->
-            <id>sonatypeDeploy</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.5.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>central</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
-                            <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.8.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -130,12 +109,43 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build-extras</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
                             </execution>
                         </executions>
                     </plugin>

--- a/src/main/java/com/projectmanager/BlobRequest.java
+++ b/src/main/java/com/projectmanager/BlobRequest.java
@@ -148,7 +148,7 @@ public class BlobRequest {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "117.0.4438.0");
+            request.addHeader("SdkVersion", "119.0.4625.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/ProjectManagerClient.java
+++ b/src/main/java/com/projectmanager/ProjectManagerClient.java
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    117.0.4438
+ * @version    119.0.4625
  * @link       https://github.com/projectmgr/projectmanager-sdk-java
  */
 
@@ -23,15 +23,15 @@ import com.projectmanager.clients.DiscussionClient;
 import com.projectmanager.clients.FileClient;
 import com.projectmanager.clients.HolidayClient;
 import com.projectmanager.clients.HomeFileClient;
-import com.projectmanager.clients.IntegrationClient;
 import com.projectmanager.clients.IntegrationCategoryClient;
+import com.projectmanager.clients.IntegrationClient;
 import com.projectmanager.clients.IntegrationProviderClient;
 import com.projectmanager.clients.LicenseClient;
 import com.projectmanager.clients.MeClient;
 import com.projectmanager.clients.NotificationClient;
 import com.projectmanager.clients.NptFilesClient;
-import com.projectmanager.clients.ProjectClient;
 import com.projectmanager.clients.ProjectChargeCodeClient;
+import com.projectmanager.clients.ProjectClient;
 import com.projectmanager.clients.ProjectCustomerClient;
 import com.projectmanager.clients.ProjectFieldClient;
 import com.projectmanager.clients.ProjectFileClient;
@@ -40,12 +40,14 @@ import com.projectmanager.clients.ProjectMembersClient;
 import com.projectmanager.clients.ProjectPriorityClient;
 import com.projectmanager.clients.ProjectStatusClient;
 import com.projectmanager.clients.ProjectTemplateClient;
+import com.projectmanager.clients.ProjectVersionClient;
 import com.projectmanager.clients.ResourceClient;
 import com.projectmanager.clients.ResourceSkillClient;
 import com.projectmanager.clients.ResourceTeamClient;
+import com.projectmanager.clients.RiskClient;
 import com.projectmanager.clients.TagClient;
-import com.projectmanager.clients.TaskClient;
 import com.projectmanager.clients.TaskAssigneeClient;
+import com.projectmanager.clients.TaskClient;
 import com.projectmanager.clients.TaskFieldClient;
 import com.projectmanager.clients.TaskFileClient;
 import com.projectmanager.clients.TaskMetadataClient;
@@ -74,15 +76,15 @@ public class ProjectManagerClient {
     private FileClient file;
     private HolidayClient holiday;
     private HomeFileClient homeFile;
-    private IntegrationClient integration;
     private IntegrationCategoryClient integrationCategory;
+    private IntegrationClient integration;
     private IntegrationProviderClient integrationProvider;
     private LicenseClient license;
     private MeClient me;
     private NotificationClient notification;
     private NptFilesClient nptFiles;
-    private ProjectClient project;
     private ProjectChargeCodeClient projectChargeCode;
+    private ProjectClient project;
     private ProjectCustomerClient projectCustomer;
     private ProjectFieldClient projectField;
     private ProjectFileClient projectFile;
@@ -91,12 +93,14 @@ public class ProjectManagerClient {
     private ProjectPriorityClient projectPriority;
     private ProjectStatusClient projectStatus;
     private ProjectTemplateClient projectTemplate;
+    private ProjectVersionClient projectVersion;
     private ResourceClient resource;
     private ResourceSkillClient resourceSkill;
     private ResourceTeamClient resourceTeam;
+    private RiskClient risk;
     private TagClient tag;
-    private TaskClient task;
     private TaskAssigneeClient taskAssignee;
+    private TaskClient task;
     private TaskFieldClient taskField;
     private TaskFileClient taskFile;
     private TaskMetadataClient taskMetadata;
@@ -118,15 +122,15 @@ public class ProjectManagerClient {
         this.file = new FileClient(this);
         this.holiday = new HolidayClient(this);
         this.homeFile = new HomeFileClient(this);
-        this.integration = new IntegrationClient(this);
         this.integrationCategory = new IntegrationCategoryClient(this);
+        this.integration = new IntegrationClient(this);
         this.integrationProvider = new IntegrationProviderClient(this);
         this.license = new LicenseClient(this);
         this.me = new MeClient(this);
         this.notification = new NotificationClient(this);
         this.nptFiles = new NptFilesClient(this);
-        this.project = new ProjectClient(this);
         this.projectChargeCode = new ProjectChargeCodeClient(this);
+        this.project = new ProjectClient(this);
         this.projectCustomer = new ProjectCustomerClient(this);
         this.projectField = new ProjectFieldClient(this);
         this.projectFile = new ProjectFileClient(this);
@@ -135,12 +139,14 @@ public class ProjectManagerClient {
         this.projectPriority = new ProjectPriorityClient(this);
         this.projectStatus = new ProjectStatusClient(this);
         this.projectTemplate = new ProjectTemplateClient(this);
+        this.projectVersion = new ProjectVersionClient(this);
         this.resource = new ResourceClient(this);
         this.resourceSkill = new ResourceSkillClient(this);
         this.resourceTeam = new ResourceTeamClient(this);
+        this.risk = new RiskClient(this);
         this.tag = new TagClient(this);
-        this.task = new TaskClient(this);
         this.taskAssignee = new TaskAssigneeClient(this);
+        this.task = new TaskClient(this);
         this.taskField = new TaskFieldClient(this);
         this.taskFile = new TaskFileClient(this);
         this.taskMetadata = new TaskMetadataClient(this);
@@ -195,17 +201,17 @@ public class ProjectManagerClient {
      */
     public @NotNull HomeFileClient getHomeFileClient() { return this.homeFile; }
     /**
-     * A collection of API methods relating to Integration
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.IntegrationClient client} methods in the API.
-     */
-    public @NotNull IntegrationClient getIntegrationClient() { return this.integration; }
-    /**
      * A collection of API methods relating to IntegrationCategory
      *
      * @return A collection containing the {@link com.projectmanager.clients.IntegrationCategoryClient client} methods in the API.
      */
     public @NotNull IntegrationCategoryClient getIntegrationCategoryClient() { return this.integrationCategory; }
+    /**
+     * A collection of API methods relating to Integration
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.IntegrationClient client} methods in the API.
+     */
+    public @NotNull IntegrationClient getIntegrationClient() { return this.integration; }
     /**
      * A collection of API methods relating to IntegrationProvider
      *
@@ -237,17 +243,17 @@ public class ProjectManagerClient {
      */
     public @NotNull NptFilesClient getNptFilesClient() { return this.nptFiles; }
     /**
-     * A collection of API methods relating to Project
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.ProjectClient client} methods in the API.
-     */
-    public @NotNull ProjectClient getProjectClient() { return this.project; }
-    /**
      * A collection of API methods relating to ProjectChargeCode
      *
      * @return A collection containing the {@link com.projectmanager.clients.ProjectChargeCodeClient client} methods in the API.
      */
     public @NotNull ProjectChargeCodeClient getProjectChargeCodeClient() { return this.projectChargeCode; }
+    /**
+     * A collection of API methods relating to Project
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.ProjectClient client} methods in the API.
+     */
+    public @NotNull ProjectClient getProjectClient() { return this.project; }
     /**
      * A collection of API methods relating to ProjectCustomer
      *
@@ -297,6 +303,12 @@ public class ProjectManagerClient {
      */
     public @NotNull ProjectTemplateClient getProjectTemplateClient() { return this.projectTemplate; }
     /**
+     * A collection of API methods relating to ProjectVersion
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.ProjectVersionClient client} methods in the API.
+     */
+    public @NotNull ProjectVersionClient getProjectVersionClient() { return this.projectVersion; }
+    /**
      * A collection of API methods relating to Resource
      *
      * @return A collection containing the {@link com.projectmanager.clients.ResourceClient client} methods in the API.
@@ -315,23 +327,29 @@ public class ProjectManagerClient {
      */
     public @NotNull ResourceTeamClient getResourceTeamClient() { return this.resourceTeam; }
     /**
+     * A collection of API methods relating to Risk
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.RiskClient client} methods in the API.
+     */
+    public @NotNull RiskClient getRiskClient() { return this.risk; }
+    /**
      * A collection of API methods relating to Tag
      *
      * @return A collection containing the {@link com.projectmanager.clients.TagClient client} methods in the API.
      */
     public @NotNull TagClient getTagClient() { return this.tag; }
     /**
-     * A collection of API methods relating to Task
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.TaskClient client} methods in the API.
-     */
-    public @NotNull TaskClient getTaskClient() { return this.task; }
-    /**
      * A collection of API methods relating to TaskAssignee
      *
      * @return A collection containing the {@link com.projectmanager.clients.TaskAssigneeClient client} methods in the API.
      */
     public @NotNull TaskAssigneeClient getTaskAssigneeClient() { return this.taskAssignee; }
+    /**
+     * A collection of API methods relating to Task
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.TaskClient client} methods in the API.
+     */
+    public @NotNull TaskClient getTaskClient() { return this.task; }
     /**
      * A collection of API methods relating to TaskField
      *

--- a/src/main/java/com/projectmanager/RestRequest.java
+++ b/src/main/java/com/projectmanager/RestRequest.java
@@ -148,7 +148,7 @@ public class RestRequest<@NotNull T> {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "117.0.4438.0");
+            request.addHeader("SdkVersion", "119.0.4625.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/clients/NotificationClient.java
+++ b/src/main/java/com/projectmanager/clients/NotificationClient.java
@@ -117,7 +117,7 @@ public class NotificationClient
      * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
      * than 1,000 pending notifications some old notifications will be deleted automatically.
      *
-     * @param id Documentation pending
+     * @param id The unique identifier of the notification to mark read
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
     public @NotNull AstroResult<NotificationTimestampDto> markNotificationRead(@NotNull String id)
@@ -149,7 +149,7 @@ public class NotificationClient
      * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
      * than 1,000 pending notifications some old notifications will be deleted automatically.
      *
-     * @param id Documentation pending
+     * @param id The unique identifier of the notification to mark read
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
     public @NotNull AstroResult<Object> deleteNotification(@NotNull String id)
@@ -166,7 +166,7 @@ public class NotificationClient
      * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
      * than 1,000 pending notifications some old notifications will be deleted automatically.
      *
-     * @param id Documentation pending
+     * @param id The unique identifier of the notification to mark read
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
     public @NotNull AstroResult<Object> markNotificationUnread(@NotNull String id)

--- a/src/main/java/com/projectmanager/clients/ProjectVersionClient.java
+++ b/src/main/java/com/projectmanager/clients/ProjectVersionClient.java
@@ -1,0 +1,105 @@
+
+/**
+ * ProjectManager API for Java
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-java
+ */
+
+
+package com.projectmanager.clients;
+
+import com.projectmanager.ProjectManagerClient;
+import com.projectmanager.RestRequest;
+import com.projectmanager.BlobRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import com.google.gson.reflect.TypeToken;
+import com.projectmanager.AstroResult;
+import com.projectmanager.models.ProjectVersionDto;
+
+
+/**
+ * Contains all methods related to ProjectVersion
+ */
+public class ProjectVersionClient
+{
+    private ProjectManagerClient client;
+
+    /**
+     * Constructor for the ProjectVersion API collection
+     *
+     * @param client A {@link com.projectmanager.ProjectManagerClient} platform client
+     */
+    public ProjectVersionClient(@NotNull ProjectManagerClient client) {
+        super();
+        this.client = client;
+    }
+
+    /**
+     * Returns projects versions including version, user who made changes
+     *
+     * @param projectId The unique identifier of the Project
+     * @return A {@link com.projectmanager.AstroResult} containing the results
+     */
+    public @NotNull AstroResult<ProjectVersionDto[]> retrieveProjectVersions(@NotNull String projectId)
+    {
+        RestRequest<ProjectVersionDto[]> r = new RestRequest<ProjectVersionDto[]>(this.client, "GET", "/api/data/projects/{projectId}/versions");
+        r.AddPath("{projectId}", projectId == null ? "" : projectId.toString());
+        return r.Call(new TypeToken<AstroResult<ProjectVersionDto[]>>() {}.getType());
+    }
+
+    /**
+     * Exports and returns project version as an MS Project XML attachment
+     *
+     * @param projectChangeId Project change Guid
+     * @return A {@link com.projectmanager.AstroResult} containing the results
+     */
+    public @NotNull AstroResult<byte[]> downloadMSProjectXml(@NotNull String projectChangeId)
+    {
+        BlobRequest r = new BlobRequest(this.client, "GET", "/api/data/projects/{projectChangeId}/version/download");
+        r.AddPath("{projectChangeId}", projectChangeId == null ? "" : projectChangeId.toString());
+        return r.Call(new TypeToken<AstroResult<byte[]>>() {}.getType());
+    }
+
+    /**
+     * Restores a Project to the state it was in at a specific Version in time.
+     *
+     * If successful, all changes made to the Project since this Version will be undone and the Project will
+     * return to its former state.
+     *
+     * @param projectId The unique identifier of the Project to restore
+     * @param version The version number to restore to
+     * @return A {@link com.projectmanager.AstroResult} containing the results
+     */
+    public @NotNull AstroResult<Object> restoreProjectVersion(@NotNull String projectId, @NotNull Integer version)
+    {
+        RestRequest<Object> r = new RestRequest<Object>(this.client, "POST", "/api/data/projects/{projectId}/version/{version}/restore");
+        r.AddPath("{projectId}", projectId == null ? "" : projectId.toString());
+        r.AddPath("{version}", version == null ? "" : version.toString());
+        return r.Call(new TypeToken<AstroResult<Object>>() {}.getType());
+    }
+
+    /**
+     * Create a Copy of a Project as of a specific Version, optionally moving it to a new Timezone.
+     *
+     * @param projectId The unique identifier of the Project to copy
+     * @param version The version number of the Project to copy
+     * @param timezoneOffset If specified, sets the default timezone of the newly copied Project to this specified timezone
+     * @return A {@link com.projectmanager.AstroResult} containing the results
+     */
+    public @NotNull AstroResult<Object> copyProjectVersion(@NotNull String projectId, @NotNull Integer version, @Nullable Integer timezoneOffset)
+    {
+        RestRequest<Object> r = new RestRequest<Object>(this.client, "POST", "/api/data/projects/{projectId}/version/{version}/copy");
+        r.AddPath("{projectId}", projectId == null ? "" : projectId.toString());
+        r.AddPath("{version}", version == null ? "" : version.toString());
+        if (timezoneOffset != null) { r.AddQuery("timezoneOffset", timezoneOffset.toString()); }
+        return r.Call(new TypeToken<AstroResult<Object>>() {}.getType());
+    }
+}

--- a/src/main/java/com/projectmanager/clients/RiskClient.java
+++ b/src/main/java/com/projectmanager/clients/RiskClient.java
@@ -1,0 +1,62 @@
+
+/**
+ * ProjectManager API for Java
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-java
+ */
+
+
+package com.projectmanager.clients;
+
+import com.projectmanager.ProjectManagerClient;
+import com.projectmanager.RestRequest;
+import com.projectmanager.BlobRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import com.google.gson.reflect.TypeToken;
+import com.projectmanager.AstroResult;
+import com.projectmanager.models.ExportDto;
+
+import com.projectmanager.models.RiskExportSettingsDto;
+
+/**
+ * Contains all methods related to Risk
+ */
+public class RiskClient
+{
+    private ProjectManagerClient client;
+
+    /**
+     * Constructor for the Risk API collection
+     *
+     * @param client A {@link com.projectmanager.ProjectManagerClient} platform client
+     */
+    public RiskClient(@NotNull ProjectManagerClient client) {
+        super();
+        this.client = client;
+    }
+
+    /**
+     * Initiates a new Export action for Risks.
+     *
+     * Returns the identifier of this Risk Export.
+     *
+     * @param projectId The unique identifier of the Project for which to export Risks
+     * @param body The settings to use for this export action
+     * @return A {@link com.projectmanager.AstroResult} containing the results
+     */
+    public @NotNull AstroResult<ExportDto> createRiskExport(@NotNull String projectId, @NotNull RiskExportSettingsDto body)
+    {
+        RestRequest<ExportDto> r = new RestRequest<ExportDto>(this.client, "POST", "/api/data/projects/{projectId}/risks/export");
+        r.AddPath("{projectId}", projectId == null ? "" : projectId.toString());
+        if (body != null) { r.AddBody(body); }
+        return r.Call(new TypeToken<AstroResult<ExportDto>>() {}.getType());
+    }
+}

--- a/src/main/java/com/projectmanager/clients/TaskMetadataClient.java
+++ b/src/main/java/com/projectmanager/clients/TaskMetadataClient.java
@@ -63,13 +63,14 @@ public class TaskMetadataClient
     }
 
     /**
+     * Get tasks by project ID and foreign key ID
      *
      * @param foreignKey Foreign Key ID
      * @param projectId Project ID
      * @param isSystem If metadata is for system or customer, isSystem = true is only of ProjectManager
      * @return A {@link com.projectmanager.AstroResult} containing the results
      */
-    public @NotNull AstroResult<TaskMetadataSearchDto[]> gettasksbyprojectIDandforeignkeyID(@Nullable String foreignKey, @NotNull String projectId, @Nullable Boolean isSystem)
+    public @NotNull AstroResult<TaskMetadataSearchDto[]> taskMetadataSearch(@Nullable String foreignKey, @NotNull String projectId, @Nullable Boolean isSystem)
     {
         RestRequest<TaskMetadataSearchDto[]> r = new RestRequest<TaskMetadataSearchDto[]>(this.client, "GET", "/api/data/projects/{projectId}/tasks/metadata");
         if (foreignKey != null) { r.AddQuery("foreignKey", foreignKey.toString()); }

--- a/src/main/java/com/projectmanager/models/DiscussionCommentFileDto.java
+++ b/src/main/java/com/projectmanager/models/DiscussionCommentFileDto.java
@@ -18,6 +18,10 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * The DiscussionCommentFile represents a file that has been attached to a discussion
+ * and is available for download.
+ */
 public class DiscussionCommentFileDto
 {
     private @NotNull String id;
@@ -49,13 +53,13 @@ public class DiscussionCommentFileDto
      */
     public void setName(@Nullable String value) { this.name = value; }
     /**
-     * The url of the file which can be used for downloading
+     * The url of the DownloadFile API to retrieve this file
      *
      * @return The field url
      */
     public @Nullable String getUrl() { return this.url; }
     /**
-     * The url of the file which can be used for downloading
+     * The url of the DownloadFile API to retrieve this file
      *
      * @param value The new value for url
      */

--- a/src/main/java/com/projectmanager/models/NotificationDataDto.java
+++ b/src/main/java/com/projectmanager/models/NotificationDataDto.java
@@ -96,11 +96,13 @@ public class NotificationDataDto
      */
     public void setProjectName(@Nullable String value) { this.projectName = value; }
     /**
+     * Name of the task this notification is related to
      *
      * @return The field taskName
      */
     public @Nullable String getTaskName() { return this.taskName; }
     /**
+     * Name of the task this notification is related to
      *
      * @param value The new value for taskName
      */

--- a/src/main/java/com/projectmanager/models/ProjectFileDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectFileDto.java
@@ -18,6 +18,10 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * The ProjectFile represents an attached file that is connected to a Project
+ * and can be retrieved for download.
+ */
 public class ProjectFileDto
 {
     private @NotNull String id;

--- a/src/main/java/com/projectmanager/models/ProjectFileTaskDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectFileTaskDto.java
@@ -18,6 +18,9 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Represents information about a Task that is relevant to a ProjectFile
+ */
 public class ProjectFileTaskDto
 {
     private @NotNull String id;

--- a/src/main/java/com/projectmanager/models/ProjectVersionChangeDataDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectVersionChangeDataDto.java
@@ -18,6 +18,11 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A ProjectVersionChangeData is information about a change made to a Project that took
+ * it from one Version to another.  The information in this object can help track the
+ * details of changes made by the user.
+ */
 public class ProjectVersionChangeDataDto
 {
     private @Nullable String type;
@@ -27,51 +32,61 @@ public class ProjectVersionChangeDataDto
     private @Nullable Integer restoreVersion;
 
     /**
+     * The type of change made
      *
      * @return The field type
      */
     public @Nullable String getType() { return this.type; }
     /**
+     * The type of change made
      *
      * @param value The new value for type
      */
     public void setType(@Nullable String value) { this.type = value; }
     /**
+     * The method used to make the change
      *
      * @return The field method
      */
     public @Nullable String getMethod() { return this.method; }
     /**
+     * The method used to make the change
      *
      * @param value The new value for method
      */
     public void setMethod(@Nullable String value) { this.method = value; }
     /**
+     * The property that was changed, if any
      *
      * @return The field property
      */
     public @Nullable String getProperty() { return this.property; }
     /**
+     * The property that was changed, if any
      *
      * @param value The new value for property
      */
     public void setProperty(@Nullable String value) { this.property = value; }
     /**
+     * The new value of the property, or null if the property was cleared
      *
      * @return The field value
      */
     public @Nullable String getValue() { return this.value; }
     /**
+     * The new value of the property, or null if the property was cleared
      *
      * @param value The new value for value
      */
     public void setValue(@Nullable String value) { this.value = value; }
     /**
+     * The prior version number to restore to
      *
      * @return The field restoreVersion
      */
     public @Nullable Integer getRestoreVersion() { return this.restoreVersion; }
     /**
+     * The prior version number to restore to
      *
      * @param value The new value for restoreVersion
      */

--- a/src/main/java/com/projectmanager/models/ProjectVersionDto.java
+++ b/src/main/java/com/projectmanager/models/ProjectVersionDto.java
@@ -18,6 +18,11 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A ProjectVersion is a snapshot of a Project at a specific moment in time.  Information on
+ * the ProjectVersion record keeps track of the unique identity of this version, plus the name
+ * and details of the user who created this version, and the changes that were made.
+ */
 public class ProjectVersionDto
 {
     private @NotNull String id;

--- a/src/main/java/com/projectmanager/models/ResourcesCreateDto.java
+++ b/src/main/java/com/projectmanager/models/ResourcesCreateDto.java
@@ -19,6 +19,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
+ * The ResourcesCreate object allows you to create multiple Users with a single API call.
+ * In ProjectManager.com, a User is a special class of Resource.
+ *
  * A Resource represents a person, material, or tool that is used within your Projects.
  * When you attach a Resources to more than one Task, the software will schedule the usage
  * of your Resource so that it is not allocated to more than one Task at the same time.
@@ -31,23 +34,27 @@ public class ResourcesCreateDto
     private @Nullable ResourceCreateDto[] users;
 
     /**
-     * When creating a user they will also be added to the projectIds specified. If null or empty the user will be invited but no access will be given to any projects.
+     * When creating a user they will also be added to the projectIds specified. If null or empty the user will be
+     * invited but no access will be given to any projects.
      *
      * @return The field projectIds
      */
     public @Nullable String[] getProjectIds() { return this.projectIds; }
     /**
-     * When creating a user they will also be added to the projectIds specified. If null or empty the user will be invited but no access will be given to any projects.
+     * When creating a user they will also be added to the projectIds specified. If null or empty the user will be
+     * invited but no access will be given to any projects.
      *
      * @param value The new value for projectIds
      */
     public void setProjectIds(@Nullable String[] value) { this.projectIds = value; }
     /**
+     * A list of Users to create
      *
      * @return The field users
      */
     public @Nullable ResourceCreateDto[] getUsers() { return this.users; }
     /**
+     * A list of Users to create
      *
      * @param value The new value for users
      */

--- a/src/main/java/com/projectmanager/models/ResourcesDto.java
+++ b/src/main/java/com/projectmanager/models/ResourcesDto.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
+ * The Resources object represents the results of a bulk Resource creation API call.
+ *
  * A Resource represents a person, material, or tool that is used within your Projects.
  * When you attach a Resources to more than one Task, the software will schedule the usage
  * of your Resource so that it is not allocated to more than one Task at the same time.
@@ -31,21 +33,25 @@ public class ResourcesDto
     private @Nullable UserError[] errors;
 
     /**
+     * The list of the Resources created by this API call.
      *
      * @return The field resources
      */
     public @Nullable ResourceDto[] getResources() { return this.resources; }
     /**
+     * The list of the Resources created by this API call.
      *
      * @param value The new value for resources
      */
     public void setResources(@Nullable ResourceDto[] value) { this.resources = value; }
     /**
+     * The list of errors that occurred for Resources that could not be created.
      *
      * @return The field errors
      */
     public @Nullable UserError[] getErrors() { return this.errors; }
     /**
+     * The list of errors that occurred for Resources that could not be created.
      *
      * @param value The new value for errors
      */

--- a/src/main/java/com/projectmanager/models/TaskDto.java
+++ b/src/main/java/com/projectmanager/models/TaskDto.java
@@ -44,6 +44,8 @@ public class TaskDto
     private @NotNull String createDate;
     private @NotNull Integer percentComplete;
     private @NotNull Boolean isSummary;
+    private @NotNull Boolean isLocked;
+    private @NotNull Boolean isMilestone;
     private @Nullable Integer priorityId;
     private @Nullable String wbs;
     private @Nullable String color;
@@ -387,6 +389,42 @@ public class TaskDto
      * @param value The new value for isSummary
      */
     public void setIsSummary(@NotNull Boolean value) { this.isSummary = value; }
+    /**
+     * Unlocked tasks can be adjusted by changes to their dependencies, resource leveling, or other factors.
+     *
+     * All tasks are unlocked by default.
+     *
+     * If a task is set to `IsLocked` = `true`, the dates and assigned resources are locked for this task and will not
+     * be automatically changed by any process.
+     *
+     * @return The field isLocked
+     */
+    public @NotNull Boolean getIsLocked() { return this.isLocked; }
+    /**
+     * Unlocked tasks can be adjusted by changes to their dependencies, resource leveling, or other factors.
+     *
+     * All tasks are unlocked by default.
+     *
+     * If a task is set to `IsLocked` = `true`, the dates and assigned resources are locked for this task and will not
+     * be automatically changed by any process.
+     *
+     * @param value The new value for isLocked
+     */
+    public void setIsLocked(@NotNull Boolean value) { this.isLocked = value; }
+    /**
+     * True if this task is a milestone.  Milestones represent a specific point in time for the project.  When a
+     * milestone is locked, it represents a fixed time within the project that can be used to relate to other tasks.
+     *
+     * @return The field isMilestone
+     */
+    public @NotNull Boolean getIsMilestone() { return this.isMilestone; }
+    /**
+     * True if this task is a milestone.  Milestones represent a specific point in time for the project.  When a
+     * milestone is locked, it represents a fixed time within the project that can be used to relate to other tasks.
+     *
+     * @param value The new value for isMilestone
+     */
+    public void setIsMilestone(@NotNull Boolean value) { this.isMilestone = value; }
     /**
      * Return the priority of a task
      *

--- a/src/main/java/com/projectmanager/models/TimesheetFileDto.java
+++ b/src/main/java/com/projectmanager/models/TimesheetFileDto.java
@@ -18,6 +18,9 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Represents information about a file attached to a Timesheet.
+ */
 public class TimesheetFileDto
 {
     private @NotNull String id;

--- a/src/main/java/com/projectmanager/models/UserError.java
+++ b/src/main/java/com/projectmanager/models/UserError.java
@@ -18,6 +18,10 @@ package com.projectmanager.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Represents an individual error for a specific Resource that could not be created in the context
+ * of a bulk Resource creation API call.
+ */
 public class UserError
 {
     private @Nullable String email;
@@ -25,31 +29,37 @@ public class UserError
     private @NotNull String statusCode;
 
     /**
+     * The email of the Resource that could not be created
      *
      * @return The field email
      */
     public @Nullable String getEmail() { return this.email; }
     /**
+     * The email of the Resource that could not be created
      *
      * @param value The new value for email
      */
     public void setEmail(@Nullable String value) { this.email = value; }
     /**
+     * A description of the reason this Resource could not be created
      *
      * @return The field reason
      */
     public @Nullable String getReason() { return this.reason; }
     /**
+     * A description of the reason this Resource could not be created
      *
      * @param value The new value for reason
      */
     public void setReason(@Nullable String value) { this.reason = value; }
     /**
+     * A status code explaining the category of reason this Resource could not be created
      *
      * @return The field statusCode
      */
     public @NotNull String getStatusCode() { return this.statusCode; }
     /**
+     * A status code explaining the category of reason this Resource could not be created
      *
      * @param value The new value for statusCode
      */

--- a/src/main/java/com/projectmanager/models/WorkSpaceDto.java
+++ b/src/main/java/com/projectmanager/models/WorkSpaceDto.java
@@ -28,7 +28,6 @@ public class WorkSpaceDto
     private @NotNull String id;
     private @Nullable String company;
     private @Nullable String customProductDomain;
-    private @Nullable String customerId;
     private @NotNull Boolean isOwner;
     private @Nullable String organizationId;
     private @Nullable String color;
@@ -73,18 +72,6 @@ public class WorkSpaceDto
      * @param value The new value for customProductDomain
      */
     public void setCustomProductDomain(@Nullable String value) { this.customProductDomain = value; }
-    /**
-     * TODO - What is this value?
-     *
-     * @return The field customerId
-     */
-    public @Nullable String getCustomerId() { return this.customerId; }
-    /**
-     * TODO - What is this value?
-     *
-     * @param value The new value for customerId
-     */
-    public void setCustomerId(@Nullable String value) { this.customerId = value; }
     /**
      * This value is set to true if the user who retrieves this Workspace object via an API call is
      * the owner of this Workspace.


### PR DESCRIPTION
# Patch notes for 119.0.4625

These patch notes summarize the changes from version 117.0.4438.

Added 5 new APIs:
* ProjectVersion.RetrieveProjectVersions (GET /api/data/projects/{projectId}/versions)
* ProjectVersion.DownloadMSProjectXml (GET /api/data/projects/{projectChangeId}/version/download)
* ProjectVersion.RestoreProjectVersion (POST /api/data/projects/{projectId}/version/{version}/restore)
* ProjectVersion.CopyProjectVersion (POST /api/data/projects/{projectId}/version/{version}/copy)
* Risk.CreateRiskExport (POST /api/data/projects/{projectId}/risks/export)

Renamed 1 old APIs:
* Renamed 'TaskMetadata.GetTasksByProjectIDAndForeignKeyID' to 'TaskMetadata.TaskMetadataSearch'

Changes to data models:
* TaskDto: Added new field `isLocked`
* TaskDto: Added new field `isMilestone`