### PR TITLE
Fix POM for SonaType central deployment

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,48 @@
+name: Check for OpenAPI updates
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # Run once per week
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET Core @ Latest
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Add the SDK Generator
+        run: dotnet tool install SdkGenerator --global
+
+      - name: Pull the latest OpenAPI file and generate the SDK
+        run: SdkGenerator build -p ./sdk-config.json
+
+      - name: Gather information
+        id: patch-notes
+        run: |
+          releasename=$(SdkGenerator get-release-name -p ./sdk-config.json)
+          echo "releasename=$releasename" >> $GITHUB_OUTPUT
+          echo "branchname=sdkgenerator-${releasename// /-}" >> $GITHUB_OUTPUT
+          {
+            echo 'patchnotes<<EOF'
+            SdkGenerator get-patch-notes -p ./sdk-config.json
+            echo EOF
+          } >> $GITHUB_OUTPUT
+          
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: ${{ steps.patch-notes.outputs.patchnotes }}
+          body: ${{ steps.patch-notes.outputs.patchnotes }}
+          title: ${{ steps.patch-notes.outputs.releasename }}
+          branch: ${{ steps.patch-notes.outputs.branchname }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         </developer>
     </developers>
 
-
+    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -41,19 +41,16 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>23.0.0</version>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5-fluent</artifactId>
@@ -61,47 +58,63 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
             </plugin>
         </plugins>
     </build>
+    
     <profiles>
         <profile>
-            <id>release</id>
+            <!-- required, used in .github/workflows/sonatype-publish.yml -->
+            <id>sonatypeDeploy</id>
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.6.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.5</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -109,43 +122,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <!-- Prevent gpg from using pinentry programs -->
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>build-extras</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.projectmanager</groupId>
     <artifactId>projectmanagersdk</artifactId>
-    <version>119.0.4625</version>
+    <version>119.0.4645</version>
 
     <name>ProjectManagerSDK</name>
     <description>Software development kit for the ProjectManager.com API. for Java</description>
@@ -33,6 +31,10 @@
         </developer>
     </developers>
 
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/projectmgr/projectmanager-sdk-java/issues</url>
+    </issueManagement>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sdk-config.json
+++ b/sdk-config.json
@@ -1,0 +1,49 @@
+{
+    "CompanyName": "ProjectManager.com",
+    "AuthorName": "ProjectManager.com",
+    "AuthorEmail": "support@projectmanager.com",
+    "ProjectName": "ProjectManager API",
+    "CopyrightHolder": "ProjectManager.com, Inc.",
+    "ProjectStartYear": 2023,
+    "SwaggerUrl": "https://api.projectmanager.com/api/swagger/ProjectManager.com,%20Inc%20API/swagger.json",
+    "Environments": [
+        {
+            "Name": "production",
+            "Url": "https://api.projectmanager.com",
+            "Default": null
+        }
+    ],
+    "SwaggerSchemaFolder": "swagger",
+    "GenericSuffixes": [
+        "AstroResult"
+    ],
+    "IgnoredParameters": [
+        {
+            "Name": "X-Integration-Name",
+            "Location": "Header"
+        }
+    ],
+    "IgnoredEndpoints": [
+        "Get Task Metadata",
+        "TaskMetadata.GetTaskMetadata"
+    ],
+    "SemverMode": 3,
+    "Keywords": "projectmanager project management task tracking projects tasks",
+    "Description": "Software development kit for the ProjectManager.com API.",
+    "AuthenticationHelp": "",
+    "ReleaseNotes": "https://learn.projectmanager.com/latest-releases",
+    "VersionNumberUrl": "https://api.projectmanager.com/api/swagger/ProjectManager.com,%20Inc%20API/swagger.json",
+    "VersionNumberRegex": "version\": \"(.*)\"",
+    "Java": {
+        "ModuleName": "ProjectManagerSDK",
+        "Folder": "C:\\github\\projectmanager-sdk-java",
+        "ClassName": "ProjectManagerClient",
+        "ResponseClass": "AstroResult",
+        "Namespace": "com.projectmanager",
+        "GithubUrl": "https://github.com/projectmgr/projectmanager-sdk-java",
+        "HandwrittenClasses": [
+            "AstroResult",
+            "AstroError"
+        ]
+    }
+}

--- a/settings.xml
+++ b/settings.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.MAVEN_USERNAME}</username>
       <password>${env.MAVEN_CENTRAL_TOKEN}</password>
     </server>

--- a/src/main/java/com/projectmanager/BlobRequest.java
+++ b/src/main/java/com/projectmanager/BlobRequest.java
@@ -148,7 +148,7 @@ public class BlobRequest {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "119.0.4625.0");
+            request.addHeader("SdkVersion", "119.0.4645.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/ProjectManagerClient.java
+++ b/src/main/java/com/projectmanager/ProjectManagerClient.java
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    119.0.4625
+ * @version    119.0.4645
  * @link       https://github.com/projectmgr/projectmanager-sdk-java
  */
 
@@ -23,15 +23,15 @@ import com.projectmanager.clients.DiscussionClient;
 import com.projectmanager.clients.FileClient;
 import com.projectmanager.clients.HolidayClient;
 import com.projectmanager.clients.HomeFileClient;
-import com.projectmanager.clients.IntegrationCategoryClient;
 import com.projectmanager.clients.IntegrationClient;
+import com.projectmanager.clients.IntegrationCategoryClient;
 import com.projectmanager.clients.IntegrationProviderClient;
 import com.projectmanager.clients.LicenseClient;
 import com.projectmanager.clients.MeClient;
 import com.projectmanager.clients.NotificationClient;
 import com.projectmanager.clients.NptFilesClient;
-import com.projectmanager.clients.ProjectChargeCodeClient;
 import com.projectmanager.clients.ProjectClient;
+import com.projectmanager.clients.ProjectChargeCodeClient;
 import com.projectmanager.clients.ProjectCustomerClient;
 import com.projectmanager.clients.ProjectFieldClient;
 import com.projectmanager.clients.ProjectFileClient;
@@ -46,8 +46,8 @@ import com.projectmanager.clients.ResourceSkillClient;
 import com.projectmanager.clients.ResourceTeamClient;
 import com.projectmanager.clients.RiskClient;
 import com.projectmanager.clients.TagClient;
-import com.projectmanager.clients.TaskAssigneeClient;
 import com.projectmanager.clients.TaskClient;
+import com.projectmanager.clients.TaskAssigneeClient;
 import com.projectmanager.clients.TaskFieldClient;
 import com.projectmanager.clients.TaskFileClient;
 import com.projectmanager.clients.TaskMetadataClient;
@@ -76,15 +76,15 @@ public class ProjectManagerClient {
     private FileClient file;
     private HolidayClient holiday;
     private HomeFileClient homeFile;
-    private IntegrationCategoryClient integrationCategory;
     private IntegrationClient integration;
+    private IntegrationCategoryClient integrationCategory;
     private IntegrationProviderClient integrationProvider;
     private LicenseClient license;
     private MeClient me;
     private NotificationClient notification;
     private NptFilesClient nptFiles;
-    private ProjectChargeCodeClient projectChargeCode;
     private ProjectClient project;
+    private ProjectChargeCodeClient projectChargeCode;
     private ProjectCustomerClient projectCustomer;
     private ProjectFieldClient projectField;
     private ProjectFileClient projectFile;
@@ -99,8 +99,8 @@ public class ProjectManagerClient {
     private ResourceTeamClient resourceTeam;
     private RiskClient risk;
     private TagClient tag;
-    private TaskAssigneeClient taskAssignee;
     private TaskClient task;
+    private TaskAssigneeClient taskAssignee;
     private TaskFieldClient taskField;
     private TaskFileClient taskFile;
     private TaskMetadataClient taskMetadata;
@@ -122,15 +122,15 @@ public class ProjectManagerClient {
         this.file = new FileClient(this);
         this.holiday = new HolidayClient(this);
         this.homeFile = new HomeFileClient(this);
-        this.integrationCategory = new IntegrationCategoryClient(this);
         this.integration = new IntegrationClient(this);
+        this.integrationCategory = new IntegrationCategoryClient(this);
         this.integrationProvider = new IntegrationProviderClient(this);
         this.license = new LicenseClient(this);
         this.me = new MeClient(this);
         this.notification = new NotificationClient(this);
         this.nptFiles = new NptFilesClient(this);
-        this.projectChargeCode = new ProjectChargeCodeClient(this);
         this.project = new ProjectClient(this);
+        this.projectChargeCode = new ProjectChargeCodeClient(this);
         this.projectCustomer = new ProjectCustomerClient(this);
         this.projectField = new ProjectFieldClient(this);
         this.projectFile = new ProjectFileClient(this);
@@ -145,8 +145,8 @@ public class ProjectManagerClient {
         this.resourceTeam = new ResourceTeamClient(this);
         this.risk = new RiskClient(this);
         this.tag = new TagClient(this);
-        this.taskAssignee = new TaskAssigneeClient(this);
         this.task = new TaskClient(this);
+        this.taskAssignee = new TaskAssigneeClient(this);
         this.taskField = new TaskFieldClient(this);
         this.taskFile = new TaskFileClient(this);
         this.taskMetadata = new TaskMetadataClient(this);
@@ -201,17 +201,17 @@ public class ProjectManagerClient {
      */
     public @NotNull HomeFileClient getHomeFileClient() { return this.homeFile; }
     /**
-     * A collection of API methods relating to IntegrationCategory
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.IntegrationCategoryClient client} methods in the API.
-     */
-    public @NotNull IntegrationCategoryClient getIntegrationCategoryClient() { return this.integrationCategory; }
-    /**
      * A collection of API methods relating to Integration
      *
      * @return A collection containing the {@link com.projectmanager.clients.IntegrationClient client} methods in the API.
      */
     public @NotNull IntegrationClient getIntegrationClient() { return this.integration; }
+    /**
+     * A collection of API methods relating to IntegrationCategory
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.IntegrationCategoryClient client} methods in the API.
+     */
+    public @NotNull IntegrationCategoryClient getIntegrationCategoryClient() { return this.integrationCategory; }
     /**
      * A collection of API methods relating to IntegrationProvider
      *
@@ -243,17 +243,17 @@ public class ProjectManagerClient {
      */
     public @NotNull NptFilesClient getNptFilesClient() { return this.nptFiles; }
     /**
-     * A collection of API methods relating to ProjectChargeCode
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.ProjectChargeCodeClient client} methods in the API.
-     */
-    public @NotNull ProjectChargeCodeClient getProjectChargeCodeClient() { return this.projectChargeCode; }
-    /**
      * A collection of API methods relating to Project
      *
      * @return A collection containing the {@link com.projectmanager.clients.ProjectClient client} methods in the API.
      */
     public @NotNull ProjectClient getProjectClient() { return this.project; }
+    /**
+     * A collection of API methods relating to ProjectChargeCode
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.ProjectChargeCodeClient client} methods in the API.
+     */
+    public @NotNull ProjectChargeCodeClient getProjectChargeCodeClient() { return this.projectChargeCode; }
     /**
      * A collection of API methods relating to ProjectCustomer
      *
@@ -339,17 +339,17 @@ public class ProjectManagerClient {
      */
     public @NotNull TagClient getTagClient() { return this.tag; }
     /**
-     * A collection of API methods relating to TaskAssignee
-     *
-     * @return A collection containing the {@link com.projectmanager.clients.TaskAssigneeClient client} methods in the API.
-     */
-    public @NotNull TaskAssigneeClient getTaskAssigneeClient() { return this.taskAssignee; }
-    /**
      * A collection of API methods relating to Task
      *
      * @return A collection containing the {@link com.projectmanager.clients.TaskClient client} methods in the API.
      */
     public @NotNull TaskClient getTaskClient() { return this.task; }
+    /**
+     * A collection of API methods relating to TaskAssignee
+     *
+     * @return A collection containing the {@link com.projectmanager.clients.TaskAssigneeClient client} methods in the API.
+     */
+    public @NotNull TaskAssigneeClient getTaskAssigneeClient() { return this.taskAssignee; }
     /**
      * A collection of API methods relating to TaskField
      *

--- a/src/main/java/com/projectmanager/RestRequest.java
+++ b/src/main/java/com/projectmanager/RestRequest.java
@@ -148,7 +148,7 @@ public class RestRequest<@NotNull T> {
             }
 
             request.addHeader("SdkName", "Java");
-            request.addHeader("SdkVersion", "119.0.4625.0");
+            request.addHeader("SdkVersion", "119.0.4645.0");
 
             String applicationName = this.client.getAppName();
 

--- a/src/main/java/com/projectmanager/models/ResourceDto.java
+++ b/src/main/java/com/projectmanager/models/ResourceDto.java
@@ -43,10 +43,10 @@ public class ResourceDto
     private @Nullable String onlineDateTime;
     private @Nullable String role;
     private @NotNull Boolean isActive;
-    private @NotNull String createdDate;
-    private @NotNull String createdBy;
-    private @NotNull String modifiedDate;
-    private @NotNull String modifiedBy;
+    private @Nullable String createdDate;
+    private @Nullable String createdBy;
+    private @Nullable String modifiedDate;
+    private @Nullable String modifiedBy;
     private @Nullable String colorName;
     private @Nullable String color;
 
@@ -287,49 +287,49 @@ public class ResourceDto
      *
      * @return The field createdDate
      */
-    public @NotNull String getCreatedDate() { return this.createdDate; }
+    public @Nullable String getCreatedDate() { return this.createdDate; }
     /**
      * The date this resource was created
      *
      * @param value The new value for createdDate
      */
-    public void setCreatedDate(@NotNull String value) { this.createdDate = value; }
+    public void setCreatedDate(@Nullable String value) { this.createdDate = value; }
     /**
      * Set to a unique identifier of the user who created this Resource.
      *
      * @return The field createdBy
      */
-    public @NotNull String getCreatedBy() { return this.createdBy; }
+    public @Nullable String getCreatedBy() { return this.createdBy; }
     /**
      * Set to a unique identifier of the user who created this Resource.
      *
      * @param value The new value for createdBy
      */
-    public void setCreatedBy(@NotNull String value) { this.createdBy = value; }
+    public void setCreatedBy(@Nullable String value) { this.createdBy = value; }
     /**
      * The date this resource was last modified
      *
      * @return The field modifiedDate
      */
-    public @NotNull String getModifiedDate() { return this.modifiedDate; }
+    public @Nullable String getModifiedDate() { return this.modifiedDate; }
     /**
      * The date this resource was last modified
      *
      * @param value The new value for modifiedDate
      */
-    public void setModifiedDate(@NotNull String value) { this.modifiedDate = value; }
+    public void setModifiedDate(@Nullable String value) { this.modifiedDate = value; }
     /**
      * Set to a unique identifier of the user who last modified this Resource.
      *
      * @return The field modifiedBy
      */
-    public @NotNull String getModifiedBy() { return this.modifiedBy; }
+    public @Nullable String getModifiedBy() { return this.modifiedBy; }
     /**
      * Set to a unique identifier of the user who last modified this Resource.
      *
      * @param value The new value for modifiedBy
      */
-    public void setModifiedBy(@NotNull String value) { this.modifiedBy = value; }
+    public void setModifiedBy(@Nullable String value) { this.modifiedBy = value; }
     /**
      * Collaboration Color for this resource.
      *

--- a/swagger/swagger-117.0.4438.json
+++ b/swagger/swagger-117.0.4438.json
@@ -1,0 +1,14244 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "ProjectManager API",
+    "description": "",
+    "contact": {
+      "name": "ProjectManager.com, Inc",
+      "url": "https://www.projectmanager.com/contact",
+      "email": "support@projectmanager.com"
+    },
+    "version": "117.0.4438"
+  },
+  "paths": {
+    "/api/data/api-keys": {
+      "post": {
+        "tags": [
+          "ApiKey"
+        ],
+        "summary": "Create Api Key",
+        "description": "Creates a new API key for the current user with the specified options.\r\n            \r\nAn API key is a credential that you can use to make REST v4 API calls for ProjectManager.com.  When you create\r\na new API key, that API key is only visible in the response JSON for the `CreateApiKey` method.  If you do not\r\npreserve this information, it cannot be recreated.\r\n            \r\nSome best practices for working with API keys:\r\n* An API key is valid for a two year period after it is created.  We encourage you to rotate your API keys\r\nregularly according to your company's security policies.\r\n* You should create separate API keys for each system that works with your API.  If that API key is exposed\r\nor if that program needs to be shut down, you can revoke that one key and reissue it.\r\n* An API key is tied to the workspace that created it. A single API key can only interact with one workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Options for the API key to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ApiKeyCreateDto"
+                  }
+                ],
+                "description": "Represents a new api access key entity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ApiKey"
+        ],
+        "summary": "List Api Keys",
+        "description": "Returns a list of all API keys within the current workspace.\r\n            \r\nAn API key is a credential that you can use to make REST v4 API calls for ProjectManager.com.  When you create\r\na new API key, that API key is only visible in the response JSON for the `CreateApiKey` method.  If you do not\r\npreserve this information, it cannot be recreated.\r\n            \r\nSome best practices for working with API keys:\r\n* An API key is valid for a two year period after it is created.  We encourage you to rotate your API keys\r\nregularly according to your company's security policies.\r\n* You should create separate API keys for each system that works with your API.  If that API key is exposed\r\nor if that program needs to be shut down, you can revoke that one key and reissue it.\r\n* An API key is tied to the workspace that created it. A single API key can only interact with one workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/api-keys/revoke-all": {
+      "delete": {
+        "tags": [
+          "ApiKey"
+        ],
+        "summary": "Revoke All Api Keys",
+        "description": "This API call revokes all existing API keys in given workspace.  No existing keys will continue to work\r\nafter this call completes.  We strongly encourage you to revoke a single API key at a time; this method\r\nshould only be used if you need to rapidly halt access to your product for automated systems.\r\n            \r\nAn API key is a credential that you can use to make REST v4 API calls for ProjectManager.com.  When you create\r\na new API key, that API key is only visible in the response JSON for the `CreateApiKey` method.  If you do not\r\npreserve this information, it cannot be recreated.\r\n            \r\nSome best practices for working with API keys:\r\n* An API key is valid for a two year period after it is created.  We encourage you to rotate your API keys\r\nregularly according to your company's security policies.\r\n* You should create separate API keys for each system that works with your API.  If that API key is exposed\r\nor if that program needs to be shut down, you can revoke that one key and reissue it.\r\n* An API key is tied to the workspace that created it. A single API key can only interact with one workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/api-keys/{id}/revoke": {
+      "delete": {
+        "tags": [
+          "ApiKey"
+        ],
+        "summary": "Revoke API Key",
+        "description": "Revokes a single API key in the current workspace.\r\n            \r\nAn API key is a credential that you can use to make REST v4 API calls for ProjectManager.com.  When you create\r\na new API key, that API key is only visible in the response JSON for the `CreateApiKey` method.  If you do not\r\npreserve this information, it cannot be recreated.\r\n            \r\nSome best practices for working with API keys:\r\n* An API key is valid for a two year period after it is created.  We encourage you to rotate your API keys\r\nregularly according to your company's security policies.\r\n* You should create separate API keys for each system that works with your API.  If that API key is exposed\r\nor if that program needs to be shut down, you can revoke that one key and reissue it.\r\n* An API key is tied to the workspace that created it. A single API key can only interact with one workspace.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the API key to revoke",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/changesets/{changeSetId}": {
+      "get": {
+        "tags": [
+          "Changeset"
+        ],
+        "summary": "Retrieve Changeset status",
+        "description": "Retrieve a Changeset by its unique ID.\r\n            \r\nA Changeset is an individual edit that has been made to a project.  Since multiple users can\r\nedit a project at the same time, individual Changesets are applied in a sequential fashion. If\r\na Changeset causes a conflict or cannot be applied, it will be rejected.  You can examine a\r\nChangeset to determine its conflict resolution status.\r\n            \r\nWhen checking the status of a Changeset, you can call either RetrieveChangeset or\r\nRetrieveCompletedChangeset.  Using RetrieveChangeset will give you the immediate status of the\r\nChangeset.  Using RetrieveCompletedChangeset will delay the response until the Changeset has\r\nfinished processing.",
+        "parameters": [
+          {
+            "name": "changeSetId",
+            "in": "path",
+            "description": "The unique ID number of the Changeset to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectChangeStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/changesets/{changeSetId}/poll": {
+      "get": {
+        "tags": [
+          "Changeset"
+        ],
+        "summary": "Retrieve Completed Changeset status",
+        "description": "Retrieve a Changeset by its unique ID. This endpoint waits for the Changeset to complete its\r\nprocessing prior to returning a result.\r\n            \r\nA Changeset is an individual edit that has been made to a project.  Since multiple users can\r\nedit a project at the same time, individual Changesets are applied in a sequential fashion. If\r\na Changeset causes a conflict or cannot be applied, it will be rejected.  You can examine a\r\nChangeset to determine its conflict resolution status.\r\n            \r\nWhen checking the status of a Changeset, you can call either RetrieveChangeset or\r\nRetrieveCompletedChangeset.  Using RetrieveChangeset will give you the immediate status of the\r\nChangeset.  Using RetrieveCompletedChangeset will delay the response until the Changeset has\r\nfinished processing.\r\n            \r\nAlthough most Changesets complete instantly, some Changesets may need additional time to\r\ncomplete.  If the Changeset cannot be processed within a reasonable length of time, this API\r\ncall may fail.  If this API fails, it will return a status error indicating the Changeset is\r\nstill being processed.",
+        "parameters": [
+          {
+            "name": "changeSetId",
+            "in": "path",
+            "description": "The unique ID number of the Changeset to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectChangeStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/changesets": {
+      "get": {
+        "tags": [
+          "Changeset"
+        ],
+        "summary": "Retrieve Changesets by project ID",
+        "description": "Retrieve Changesets by Project ID",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetDtoListAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/data/dashboards/settings/{type}": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Retrieve Dashboard User Settings",
+        "description": "Returns user dashboard settings",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "description": "The dashboard type that is not custom",
+            "required": true,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DashboardType"
+                }
+              ]
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSettingDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/dashboards/settings": {
+      "post": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Create or Update User Dashboard Settings",
+        "description": "Create or Update User Dashboard Settings",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "User dashboard settings object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DashboardSettingCreateDto"
+                  }
+                ],
+                "description": "User dashboard create or update dto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSettingDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/comments": {
+      "get": {
+        "tags": [
+          "Discussion"
+        ],
+        "summary": "Retrieve Task Comments",
+        "description": "Retrieve all comments written about a task",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique ID number of the task to retrieve comments",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscussionCommentDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Discussion"
+        ],
+        "summary": "Create Task Comments",
+        "description": "Adds a Markdown-formatted comment to a task.\r\n            \r\nTasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique ID number of the task being commented upon",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The Markdown-formatted text of the comment",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DiscussionCommentCreateDto"
+                  }
+                ],
+                "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscussionCommentCreateResponseDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/discussions": {
+      "get": {
+        "tags": [
+          "Discussion"
+        ],
+        "summary": "Retrieve Task Comments",
+        "description": "Retrieve all comments written about a task",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique ID number of the task to retrieve comments",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscussionCommentDtoListAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Discussion"
+        ],
+        "summary": "Create Task Comments",
+        "description": "Adds a Markdown-formatted comment to a task.\r\n            \r\nTasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique ID number of the task being commented upon",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The Markdown-formatted text of the comment",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DiscussionCommentCreateDto"
+                  }
+                ],
+                "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscussionCommentCreateResponseDtoAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/data/files/{documentId}/download": {
+      "get": {
+        "tags": [
+          "File"
+        ],
+        "summary": "Download File",
+        "description": "Downloads the contents of a file that was previously uploaded to ProjectManager.com.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nIf successful, this API returns the file contents as an octet-stream (raw bytes).  If an error\r\noccurs, you will receive a JSON result with error information.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The unique identifier of the document to download",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "If you specify a type of `html`, processes the file using text encoding, otherwise binary",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/files/{documentId}/thumbnail": {
+      "get": {
+        "tags": [
+          "File"
+        ],
+        "summary": "Download a Thumbnail Image",
+        "description": "Downloads a thumbnail image associated with a document that was previously uploaded to ProjectManager.com.\r\n            \r\nProjectManager allows you to store files linked to various elements within your Workspace,\r\nsuch as Projects, Tasks, or your Home. Files are organized based on their storage location.\r\n            \r\nWhen uploading a file, please allow some time for the file to undergo processing and verification.\r\nProjectManager may reject file uploads containing issues such as malware. Once a file has\r\ncompleted the upload process, you can retrieve its associated thumbnail using the DownloadThumbnail API.\r\n            \r\nIf successful, this API returns the file contents as an octet-stream (raw bytes).  If an error\r\noccurs, you will receive a JSON result with error information.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The unique identifier of the document for which to download the thumbnail.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/files/{fileId}": {
+      "put": {
+        "tags": [
+          "File"
+        ],
+        "summary": "Update File",
+        "description": "Updates information about a File uploaded to your Workspace.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The unique identifier of the File to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information to change about the File and its location",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateRequestDto"
+                  }
+                ],
+                "description": "Represents an update request for a File within ProjectManager.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project or a Discussion.  When you upload a File, please allow a few moments\r\nfor the File to be processed and verified.  ProjectManager may reject File uploads that\r\ncontain problems such as malware. Once a File has completed the upload the process, you\r\nmay retrieve it using the DownloadFile API."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "File"
+        ],
+        "summary": "Delete file",
+        "description": "In case of soft delete moves file to trash folder. For hard delete completely deletes\r\nfile's metadata from pm database as well as from amazon storage\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The unique identifier of the File to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "hard",
+            "in": "query",
+            "description": "Param indicates that file should be hard deleted",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/holidays/resource": {
+      "get": {
+        "tags": [
+          "Holiday"
+        ],
+        "summary": "Query resource holidays",
+        "description": "Retrieve a list of resource holidays that match an [OData formatted query](https://www.odata.org/).",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceHolidayDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/holidays/country": {
+      "get": {
+        "tags": [
+          "Holiday"
+        ],
+        "summary": "Query country holidays",
+        "description": "Retrieve a list of country holidays that match an [OData formatted query](https://www.odata.org/).",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountryHolidayDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/holidays/global": {
+      "get": {
+        "tags": [
+          "Holiday"
+        ],
+        "summary": "Query global holidays",
+        "description": "Retrieve a list of global holidays that match an [OData formatted query](https://www.odata.org/).",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalHolidayDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/home/files": {
+      "post": {
+        "tags": [
+          "HomeFile"
+        ],
+        "summary": "Upload Home File",
+        "description": "Uploads a file to the My Files folder on your Home Files page.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/home/folders/{folderId}/files": {
+      "post": {
+        "tags": [
+          "HomeFile"
+        ],
+        "summary": "Upload Home File To Folder",
+        "description": "Uploads a file to a specific folder on your Home Files page.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nYou can organize your files in the Home Files and Project Files pages by adding folders.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "The reference to the sub folder to put the file into",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/{integrationId}": {
+      "get": {
+        "tags": [
+          "Integration"
+        ],
+        "summary": "Retrieve Integration",
+        "description": "Retrieves an Integration specified by a unique identifier.\r\n            \r\nThe Integrations API is intended for use by ProjectManager and its business development partners.  Please\r\ncontact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "integrationId",
+            "in": "path",
+            "description": "The unique identifier of this Integration",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Integration"
+        ],
+        "summary": "Enable Integration",
+        "description": "Enable a specific Integration for the current Workspace.\r\n            \r\nThe Integrations API is intended for use by ProjectManager and its business development partners.  Please\r\ncontact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "integrationId",
+            "in": "path",
+            "description": "The unique identifier of the Integration to enable",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Integration"
+        ],
+        "summary": "Disable Integration",
+        "description": "Disable a specific Integration for the current Workspace.\r\n            \r\nThe Integrations API is intended for use by ProjectManager and its business development partners.  Please\r\ncontact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "integrationId",
+            "in": "path",
+            "description": "The unique identifier of the Integration to disable",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations": {
+      "get": {
+        "tags": [
+          "Integration"
+        ],
+        "summary": "Retrieve All Integrations",
+        "description": "Retrieves all Integrations for the current Workspace.\r\n            \r\nThe Integrations API is intended for use by ProjectManager and its business development partners.  Please\r\ncontact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/categories": {
+      "get": {
+        "tags": [
+          "IntegrationCategory"
+        ],
+        "summary": "Retrieve Provider Categories",
+        "description": "Retrieves the list of available IntegrationProvider categories.\r\n            \r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationCategoryDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/providers": {
+      "get": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "List Providers",
+        "description": "List all available IntegrationProviders that can be activated.\r\n            \r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationProviderDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/providers/{providerId}": {
+      "post": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Activate Integration Provider",
+        "description": "Activates an Integration Provider and retrieves authentication information about a specific IntegrationProvider.\r\n            \r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The unique identifier of the IntegrationProvider for which you are requesting authentication information",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionSchemaDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Update Integration Provider",
+        "description": "Allows you to update the auth status of the provider specific connection.\r\n\r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The identifier to the provider",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Specify the auth status",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AuthenticationDto"
+                  }
+                ],
+                "description": "Set the connection status of an integration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Deactivate Integration Provider",
+        "description": "Allows you to deactivate an integration provider.\r\n\r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The identifier to the provider",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/providers/{providerId}/user-connection": {
+      "post": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Create User Integration Provider Connection",
+        "description": "Retrieves user authentication information about a specific IntegrationProvider.\r\n            \r\nThis connection can be used for requests to Providers that require specific user data.\r\n\r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The unique identifier of the IntegrationProvider for which you are requesting authentication information",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DirectLinkDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Update User Integration Provider Connection",
+        "description": "Allows you to update the auth status of the provider specific user connection.\r\n\r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The identifier to the provider",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Specify the auth status",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AuthenticationStatusDto"
+                  }
+                ],
+                "description": "Set the connection status of an integration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "IntegrationProvider"
+        ],
+        "summary": "Disconnect User Integration Provider Connection",
+        "description": "Allows you to disconnect the provider specific user connection.\r\n\r\nAn IntegrationProvider is the name of an external application or service that can be connected to\r\nProjectManager.com.  The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "description": "The identifier to the provider",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/license": {
+      "get": {
+        "tags": [
+          "License"
+        ],
+        "summary": "Retrieve Licenses",
+        "description": "Retrieve information about the current licenses possessed by this Workspace.\r\n            \r\nLicenses contain information about your current subscription level and features that have\r\nbeen enabled on your Workspace.  To modify the License information, please log on to the\r\nProjectManager.com application and use the Account | Editions screen to review or update\r\nyour Licenses.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LicenseDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/license/{bundleSku}/try": {
+      "post": {
+        "tags": [
+          "License"
+        ],
+        "summary": "Add License",
+        "description": "Adds a new License to the current Workspace.\r\n            \r\nLicenses contain information about your current subscription level and features that have\r\nbeen enabled on your Workspace.  To modify the License information, please log on to the\r\nProjectManager.com application and use the Account | Editions screen to review or update\r\nyour Licenses.",
+        "parameters": [
+          {
+            "name": "bundleSku",
+            "in": "path",
+            "description": "Information about the SKU you wish to add to your Workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LicenseDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/me": {
+      "get": {
+        "tags": [
+          "Me"
+        ],
+        "summary": "Retrieve Me",
+        "description": "Retrieve information about the currently logged on user.\r\n            \r\nThis API call will always succeed with a 200 OK if called with valid authentication information.\r\nIf the authentication information provided is not valid, calling this API will return a 401\r\nAuthentication Failed error message.  If successful, this API returns information about the user\r\nincluding its home URL, email address, user name, and workspace name.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSpaceUserInfoDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Retrieve Notifications",
+        "description": "Retrieve the most recent notifications for the current user, along with the amount of notifications.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.\r\n            \r\nThis API retrieves 500 notifications at a time.  To fetch more than 500 notifications, repeat this API call\r\nusing the parameter `lastId` of the oldest notification from each batch to fetch the next 500 notifications.",
+        "parameters": [
+          {
+            "name": "lastId",
+            "in": "query",
+            "description": "To continue loading more notifications in a series of requests, provide the ID of the oldest notification from\r\nthe currently loaded batch as the `lastId` parameter",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponseDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/count": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Notification Count",
+        "description": "Retrieve the total count of pending notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationTotalCountDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/unreadcount": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Unread Notification Count",
+        "description": "Retrieve the count of unread notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationUnreadCountDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/deleteall": {
+      "delete": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Delete All Notifications",
+        "description": "Delete all pending notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/{id}/markread": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Mark Notification Read",
+        "description": "Marks a pending notification as read.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationTimestampDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/markallread": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Read All Notifications",
+        "description": "Marks all pending notification for the current user as read.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationTimestampDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/delete/{id}": {
+      "delete": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Delete Notification",
+        "description": "Deletes a pending notification that is no longer wanted.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/notifications/{id}/markunread": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "summary": "Mark Notification Unread",
+        "description": "Marks a pending notification as unread.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/non-project-tasks/{taskId}/files": {
+      "post": {
+        "tags": [
+          "NptFiles"
+        ],
+        "summary": "Upload File To Non Project Tasks",
+        "description": "Uploads a file to a non-project task.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The reference to the task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects": {
+      "get": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Query Projects",
+        "description": "Retrieve a list of Projects that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Create Project",
+        "description": "Create a new project based on the details provided.\r\n            \r\nA Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the Project you wish to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProjectCreateDto"
+                  }
+                ],
+                "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.\r\n            \r\nFields that cannot be selected during a CreateProject API call are not visible on this\r\ndata model."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}": {
+      "get": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Retrieve Project",
+        "description": "Retrieves a project based on its unique identifier.\r\n            \r\nA Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Update Project",
+        "description": "Update an existing Project and replace the values of fields specified.\r\n            \r\nA Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.\r\n            \r\nMultiple users can be working on data at the same time.  When you call an API to update an\r\nobject, this call is converted into a Changeset that is then applied sequentially.  You can use\r\nRetrieveChangeset to see the status of an individual Changeset.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "All non-null fields in this object will replace previous data within the Project",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProjectUpdateDto"
+                  }
+                ],
+                "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.\r\n            \r\nFields that cannot be modified during an UpdateProject call are not visible on this data\r\nmodel."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Delete Project",
+        "description": "Delete a project based on the details provided.\r\n            \r\nA Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "hardDelete",
+            "in": "query",
+            "description": "Hard delete project true or false",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/chargecodes": {
+      "get": {
+        "tags": [
+          "ProjectChargeCode"
+        ],
+        "summary": "Retrieve Charge Codes",
+        "description": "Retrieve all defined ChargeCodes that can be used when creating Projects.\r\n            \r\nA ChargeCode is a code used to identify costs within your Projects.  Each ChargeCode has\r\na name and a unique identifier.  ChargeCodes are defined per Workspace and are shared\r\namong Projects.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectChargeCodeDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/customers": {
+      "get": {
+        "tags": [
+          "ProjectCustomer"
+        ],
+        "summary": "Retrieve Project Customers",
+        "description": "Retrieves all ProjectCustomers defined within your Workspace.\r\n            \r\nA ProjectCustomer is a code used to identify customers associated with your Projects.  Each\r\nProjectCustomer has a name and a unique identifier.  ProjectCustomers are defined per\r\nWorkspace and are shared among Projects.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectCustomerDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/fields": {
+      "get": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Retrieve Project Fields",
+        "description": "Retrieves all ProjectFields defined within your Workspace.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectFieldDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Create Project Field",
+        "description": "Creates a new ProjectField within your Workspace.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the ProjectField to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProjectFieldCreateDto"
+                  }
+                ],
+                "description": "A ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectFieldDtoAstroResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "error": {
+                      "message": "Input Validation Failed",
+                      "validationErrors": {
+                        "name": [
+                          "'name' must not be empty."
+                        ],
+                        "shortId": [
+                          "'shortId' is not in the correct format."
+                        ],
+                        "type": [
+                          "'type' must not be empty.",
+                          "type must be one of the following: string, number, date, bool, currency, dropdown-single, dropdown-multi"
+                        ],
+                        "options": [
+                          "'options' must not be empty.",
+                          "options must contain at least 2 items",
+                          "'options' must be empty."
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/fields/{fieldId}": {
+      "delete": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Delete Project Field",
+        "description": "Deletes an existing ProjectField within your Workspace.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier or short ID  of this ProjectField",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/fields/{fieldId}": {
+      "put": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Update ProjectField Value",
+        "description": "Replaces the current value of a ProjectField for a specific Project within your Workspace.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project that contains this ProjectField",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier or short ID  of this ProjectField",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new information for this ProjectField",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateProjectFieldValueDto"
+                  }
+                ],
+                "description": "A model that contains a new value to be set for a ProjectField."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Retrieve ProjectField Value",
+        "description": "Retrieves the current ProjectField value for a particular Project and ProjectField.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier or short ID of the ProjectField of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectFieldValueDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/fields": {
+      "get": {
+        "tags": [
+          "ProjectField"
+        ],
+        "summary": "Retrieve All ProjectField Values",
+        "description": "Retrieves all ProjectField values for a particular Project.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project for which we want ProjectField values",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectFieldValueDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/files": {
+      "post": {
+        "tags": [
+          "ProjectFile"
+        ],
+        "summary": "Upload Project File",
+        "description": "Uploads a file to the All Files folder on the Files page within the project that you specify.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The reference to the project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/folders/{folderId}/files": {
+      "post": {
+        "tags": [
+          "ProjectFile"
+        ],
+        "summary": "Upload Project File To Folder",
+        "description": "Uploads a file to a specific folder on the Files page within the project that you specify.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nYou can organize your files in the Home Files and Project Files pages by adding folders.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The reference to the project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "The reference to the sub folder to put the file into",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/project-folders": {
+      "get": {
+        "tags": [
+          "ProjectFolder"
+        ],
+        "summary": "Retrieve Project Folders",
+        "description": "Retrieves all ProjectFolders defined within your Workspace.\r\n            \r\nA ProjectFolder is a named storage location that can contain Projects.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectFolderDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/members": {
+      "get": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Retrieve New Project Members",
+        "description": "Returns a list of users that can be added as members of a new project, as well as their available project security roles. \r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectMemberDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/members": {
+      "get": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Retrieve Project Members",
+        "description": "Returns a list of users that are currently members of a specified project, as well as their current project security roles and available project security roles. \r\nOptionally include users who are not currently members of the project, but who are available to be added.\r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Reference to the project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "includeAllUsers",
+            "in": "query",
+            "description": "Set to true to include all users in the workspace",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectMemberDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/members/{userId}": {
+      "get": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Retrieve User Project Membership",
+        "description": "Returns the project security role in a specified project for a current project member.\r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Reference of Project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "Reference of User",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectMemberDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Create User Project Membership",
+        "description": "Creates a membership for a user in a specified project, and assigns the user the appropriate project access based on the specified project security role.\r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Reference to Project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "Reference to User",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The permission to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProjectMemberRoleDto"
+                  }
+                ],
+                "description": "Dto To Describe a ProjectMember Role"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectMemberDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Update User Project Membership",
+        "description": "Updates the project access for a current member of a specified project by giving the user a new project security role.\r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Reference to Project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "Reference to User",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The permission to update",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProjectMemberRoleDto"
+                  }
+                ],
+                "description": "Dto To Describe a ProjectMember Role"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectMemberDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ProjectMembers"
+        ],
+        "summary": "Remove User Project Membership",
+        "description": "Removes a current project member from a specified project. This removes the user's access to that project.\r\n\r\nA project member is a user who has access to a specific project. Project members are assigned a project security role, which controls the level of access they have to \r\nthe project. Possible project security roles include manage, edit, collaborate, creator, and guest.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Reference to Project",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "Reference to User",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/priorities": {
+      "get": {
+        "tags": [
+          "ProjectPriority"
+        ],
+        "summary": "Retrieve Project Priorities",
+        "description": "Retrieves all ProjectPriorities defined within your Workspace.\r\n            \r\nA ProjectPriority is a named priority level used by your business to determine how to decide\r\nwhich Projects are the most important.  You can name your ProjectPriority levels anything you like\r\nand you can reorganize the order of the ProjectPriority levels at any time.\r\n            \r\nNote that TaskPriority and ProjectPriority are different classes of priority levels.  Even\r\nif they may have similar names, they are different objects and must be tracked separately.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectPriorityDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/statuses": {
+      "get": {
+        "tags": [
+          "ProjectStatus"
+        ],
+        "summary": "Retrieve Project Statuses",
+        "description": "Retrieves all ProjectStatuses defined within your Workspace.\r\n            \r\nA ProjectStatus is a named condition used by your business to categorize the completion level\r\nof Tasks and Projects within your Workspace.  You can name your ProjectStatus levels anything\r\nyou like and you can reorganize the order of the ProjectPriority levels at any time.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectStatusDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/templates": {
+      "get": {
+        "tags": [
+          "ProjectTemplate"
+        ],
+        "summary": "Retrieve Project Templates",
+        "description": "Retrieves all ProjectTemplates defined in the system.\r\n            \r\nA ProjectTemplate is a definition of default project related data (eg. Tasks) that can be applied\r\nto a new project when it is created.  ProjectTemplates are categorized using the TemplateCategory\r\nsystem.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectTemplateDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/templates/categories": {
+      "get": {
+        "tags": [
+          "ProjectTemplate"
+        ],
+        "summary": "Retrieve Template Categories",
+        "description": "Retrieves all ProjectTemplate Categories defined in the system.\r\n            \r\nA ProjectTemplate is a definition of default project related data (eg. Tasks) that can be applied\r\nto a new project when it is created.  ProjectTemplates are categorized using the TemplateCategory\r\nsystem.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectTemplateCategoryDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/versions": {
+      "get": {
+        "tags": [
+          "ProjectVersion"
+        ],
+        "summary": "Retrieve project's version",
+        "description": "Returns projects versions including version, user who made changes",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectVersionDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectChangeId}/version/download": {
+      "get": {
+        "tags": [
+          "ProjectVersion"
+        ],
+        "summary": "Retrieve project's data in MS Project xml format",
+        "description": "Exports and returns project version into MS Project xml",
+        "parameters": [
+          {
+            "name": "projectChangeId",
+            "in": "path",
+            "description": "Project change Guid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/version/{version}/restore": {
+      "post": {
+        "tags": [
+          "ProjectVersion"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/version/{version}/copy": {
+      "post": {
+        "tags": [
+          "ProjectVersion"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "timezoneOffset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources": {
+      "post": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Create Resource",
+        "description": "Create a new Resource within your Workspace.\r\n            \r\nA Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The details for the new Resource to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ResourceCreateDto"
+                  }
+                ],
+                "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Query Resources",
+        "description": "Retrieve a list of Resources that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/{resourceId}": {
+      "put": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Update Resource",
+        "description": "Updates an existing Resource based on information you provide.\r\n            \r\nA Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The id of the resource",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The information to update the resource",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ResourceUpdateDto"
+                  }
+                ],
+                "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Retrieve Resource",
+        "description": "Retrieve the Resource matching the specified unique ID.\r\n            \r\nA Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The id of the Resource",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/bulk": {
+      "post": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Create Many Resources",
+        "description": "Create new Resources within your Workspace.\r\n            \r\nA Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The details for the new Resources to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ResourcesCreateDto"
+                  }
+                ],
+                "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourcesDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/{resourceId}/resendinvite": {
+      "get": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Resend Invite Email",
+        "description": "Resend Invite Email to a Resource within your Workspace.\r\n            \r\nWhen you create a Resource that is a person, ProjectManager sends that person an email inviting them to join\r\nyour Workspace.  If that email is accidentally deleted or sent to a spam folder, you can request this email\r\nbe sent again using this API.",
+        "parameters": [
+          {
+            "name": "resourceId",
+            "in": "path",
+            "description": "The unique identifier of the Resource to send an invitation email",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/skills": {
+      "get": {
+        "tags": [
+          "ResourceSkill"
+        ],
+        "summary": "Retrieve Resource Skills",
+        "description": "Retrieves all ResourceSkills defined within your Workspace.\r\n            \r\nA ResourceSkill is a capability possessed by a Resource that can be used to distinguish\r\ndifferent classes of Resources suitable for use by a Task.  You can specify that a Task\r\nrequires a Resource with a particular set of ResourceSkills and then allocate Resources\r\nbased on whether or not they have the suitable ResourceSkills.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSkillDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ResourceSkill"
+        ],
+        "summary": "Create Resource Skill",
+        "description": "Create a Resource Skill.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The name of the skill to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateResourceSkillDto"
+                  }
+                ],
+                "description": "This is a skill that can be allocated to a resource."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSkillDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/skills/{skillId}": {
+      "put": {
+        "tags": [
+          "ResourceSkill"
+        ],
+        "summary": "Update Resource Skill",
+        "description": "Update a Resource Skill.",
+        "parameters": [
+          {
+            "name": "skillId",
+            "in": "path",
+            "description": "The id of the skill to update.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The data of the skill to update.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateResourceSkillDto"
+                  }
+                ],
+                "description": "This is a skill that can be allocated to a resource."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSkillDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/skills/{resourceSkillId}": {
+      "delete": {
+        "tags": [
+          "ResourceSkill"
+        ],
+        "summary": "Delete Resource Skill",
+        "description": "The endpoint is used to delete a resource skill. Users assigned to this skill will no longer be assigned thereafter.",
+        "parameters": [
+          {
+            "name": "resourceSkillId",
+            "in": "path",
+            "description": "The Id of the skill to be removed.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/teams": {
+      "get": {
+        "tags": [
+          "ResourceTeam"
+        ],
+        "summary": "Retrieve Resource Teams",
+        "description": "Retrieves all ResourceTeams defined within your Workspace that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA ResourceTeam is a grouping of Resources that allows you to keep track of assignments\r\nin a manner consistent with your business needs.  You can assign Resources to be members\r\nof zero, one, or many ResourceTeams.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceTeamDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ResourceTeam"
+        ],
+        "summary": "Create Resource Team",
+        "description": "Create a Resource Team.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The name of the team to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateResourceTeamDto"
+                  }
+                ],
+                "description": "A resource can be allocated a team."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceTeamDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/teams/{resourceTeamId}": {
+      "delete": {
+        "tags": [
+          "ResourceTeam"
+        ],
+        "summary": "Delete Resource Team",
+        "description": "The endpoint is used to delete a resource team. Users assigned to this team will no longer be assigned thereafter.",
+        "parameters": [
+          {
+            "name": "resourceTeamId",
+            "in": "path",
+            "description": "The Id of the team to be removed.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/resources/teams/{teamresourceId}": {
+      "put": {
+        "tags": [
+          "ResourceTeam"
+        ],
+        "summary": "Update Resource Team",
+        "description": "Update a Resource Team.",
+        "parameters": [
+          {
+            "name": "teamresourceId",
+            "in": "path",
+            "description": "The id of the resource team",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The name of the team to Update.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateResourceTeamDto"
+                  }
+                ],
+                "description": "A resource can update a team."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceTeamDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/risks/export": {
+      "post": {
+        "tags": [
+          "Risk"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RiskExportSettingsDto"
+                  }
+                ],
+                "description": "Export Settings for Risk Export"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportDtoAstroResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "error": {
+                      "message": "Input Validation Failed",
+                      "validationErrors": {
+                        "format": [
+                          "format must be one of the following: Csv, excel"
+                        ],
+                        "timeZoneOffset": [
+                          "'timeZoneOffset' must be between {From} and {To}. You entered {PropertyValue}."
+                        ],
+                        "columns": [
+                          "'columns' must not be empty.",
+                          "'columns' must not be empty.",
+                          "The specified condition was not met for 'columns'."
+                        ],
+                        "orderBy": [
+                          "orderBy must be one of the following: name, createDate, assignees, dueDate, impact, level, likelihood, openClosed, priority, response, tags, description, resolution"
+                        ],
+                        "orderDirection": [
+                          "orderDirection must be one of the following: asc, desc"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tags": {
+      "get": {
+        "tags": [
+          "Tag"
+        ],
+        "summary": "Query Tags",
+        "description": "Retrieve a list of Tags that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tag"
+        ],
+        "summary": "Create Tag",
+        "description": "Creates a new Tag based on information you provide.\r\n            \r\nA Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The information for the new Tag to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TagCreateDto"
+                  }
+                ],
+                "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tags/{tagId}": {
+      "put": {
+        "tags": [
+          "Tag"
+        ],
+        "summary": "Update Tag",
+        "description": "Updates an existing Tag based on information you provide.\r\n            \r\nA Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color.",
+        "parameters": [
+          {
+            "name": "tagId",
+            "in": "path",
+            "description": "The id of the tag",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The information to update the tag",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TagUpdateDto"
+                  }
+                ],
+                "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Query Tasks",
+        "description": "Retrieve a list of Tasks that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Retrieve Task",
+        "description": "Retrieve a Task by its unique identifier or by its short ID.  A Task has both a unique\r\nidentifier, which is a GUID, and a short ID, which is a small text label that is unique\r\nonly within your Workspace.\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier or short ID of the Task to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Update Task",
+        "description": "Update an existing Task and replace the values of fields specified.\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.\r\n            \r\nMultiple users can be working on data at the same time.  When you call an API to update an\r\nobject, this call is converted into a Changeset that is then applied sequentially.  You can use\r\nRetrieveChangeset to see the status of an individual Changeset.\r\n            \r\nKnown Issues:  This API returns an error if your Update call includes too many changes in a\r\nsingle API call.  Please restrict usage to one change per API request.  This API will be\r\ndeprecated and replaced with an improved API call in a future release.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "All non-null fields in this object will replace existing data in the Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TaskUpdateDto"
+                  }
+                ],
+                "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Delete Task",
+        "description": "Delete an existing Task.\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.\r\n            \r\nMultiple users can be working on data at the same time.  When you call an API to update an\r\nobject, this call is converted into a Changeset that is then applied sequentially.  You can use\r\nRetrieveChangeset to see the status of an individual Changeset.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "Unique identifier of the Task to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks": {
+      "post": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Create Task",
+        "description": "Create a new Task within a specified project.\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project that will contain this Task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new Task to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TaskCreateDto"
+                  }
+                ],
+                "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/priorities": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Retrieve Task Priorities",
+        "description": "Retrieves all TaskPriorities defined within your Workspace.\r\n            \r\nA TaskPriority is a named priority level used by your business to determine how to decide\r\nwhich Tasks are the most important.  You can name your TaskPriority levels anything you like\r\nand you can reorganize the order of the TaskPriority levels at any time.\r\n            \r\nNote that TaskPriority and ProjectPriority are different classes of priority levels.  Even\r\nif they may have similar names, they are different objects and must be tracked separately.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskPriorityDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/bulk": {
+      "post": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Create Many Tasks",
+        "description": "Create multiple new Tasks within a specified project with a single API call.\r\n            \r\nA Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project that will contain these Tasks",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The list of new Tasks to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TaskCreateDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/parent/{parentTaskId}": {
+      "post": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Add Parent Task",
+        "description": "Adds a task parent relationship",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The task that will become the child",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parentTaskId",
+            "in": "path",
+            "description": "The parent task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Update Parent Task",
+        "description": "Updates a task parent relationship",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The task that will become the child",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parentTaskId",
+            "in": "path",
+            "description": "The parent task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/parent": {
+      "delete": {
+        "tags": [
+          "Task"
+        ],
+        "summary": "Remove Parent Task",
+        "description": "Removes a task parent relationship completely",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The child task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/assignees": {
+      "post": {
+        "tags": [
+          "TaskAssignee"
+        ],
+        "summary": "Replace Task Assignees",
+        "description": "Replace all TaskAssignees on a Task with new TaskAssignees.\r\n            \r\nA TaskAssignee is an assignment of a Resource to a Task.  You can assign multiple Resources\r\nto a Task and designate how much of their time will be allocated to this Task.\r\n\r\nIn the request body, id is the id of the Resource you would like to assign to the Task, and \r\nassignedEffort is the amount of time that Resource is expected to spend on the task. assignedEffort \r\nshould be entered in minutes.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task whose TaskAssignees will be replaced",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new list of TaskAssignees for this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AssigneeUpsertDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TaskAssignee"
+        ],
+        "summary": "Create Or Update TaskAssignee",
+        "description": "Adds or updates a TaskAssignee to a Task.  If the TaskAssignee is already assigned to the Task, update\r\ntheir allocation.  If the TaskAssignee is not yet assigned to the Task, assign them and set their\r\nallocation level to the correct amount.\r\n            \r\nA TaskAssignee is an assignment of a Resource to a Task.  You can assign multiple Resources\r\nto a Task and designate what proportion of their time will be allocated to this Task.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task to add or update an assignment",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "List of Assignee data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AssigneeUpsertDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TaskAssignee"
+        ],
+        "summary": "Delete Task Assignees",
+        "description": "Remove one or more TaskAssignees from a Task.\r\n            \r\nA TaskAssignee is an assignment of a Resource to a Task.  You can assign multiple Resources\r\nto a Task and designate what proportion of their time will be allocated to this Task.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task whose TaskAssignee will be removed",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "List of TaskAssignee records to remove",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IdDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/fields": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Retrieve Task Fields",
+        "description": "Retrieves all TaskFields defined for a specific Project within your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project to retrieve TaskFields",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Create Task Field",
+        "description": "Creates a new TaskField for a specific Project within your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project within which to create this TaskField",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the TaskField to create",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateTaskFieldDto"
+                  }
+                ],
+                "description": "A TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/tasks/fields": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Query Task Fields",
+        "description": "Retrieve a list of TaskFields that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside a Project.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/fields/{fieldId}": {
+      "delete": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Delete Task Field",
+        "description": "Deletes a TaskField for a specific Project within your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project that contains this TaskField",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier of the TaskField to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/fields/values": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Retrieve All TaskField Values",
+        "description": "Retrieves all TaskField values for a particular Task.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task for which we want TaskField values",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldValueDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/fields/values": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Query Task Field Values",
+        "description": "Retrieve a list of TaskFieldValues that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldValueDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/fields/{fieldId}/values": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Retrieve Task Field Value",
+        "description": "Retrieves the current TaskField value for a particular Task and TaskField.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier of the TaskField of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldValueDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Update Task Field Value",
+        "description": "Replaces the current value of a TaskField for a specific Task within your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task whose value you wish to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier of the TaskField whose value you wish to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new value for this TaskField for this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateTaskFieldValueDto"
+                  }
+                ],
+                "description": "A model that contains a new value to be set for a TaskField."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/fields/{fieldId}": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Retrieve Task Field Value",
+        "description": "This endpoint has been replace with `tasks/{taskId}/fields/{fieldId}/values`",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier of the TaskField of the value to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldValueDtoAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "put": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Update Task Field Value",
+        "description": "This endpoint has been replace with `tasks/{taskId}/fields/{fieldId}/values`",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task whose value you wish to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "The unique identifier of the TaskField whose value you wish to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new value for this TaskField for this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateTaskFieldValueDto"
+                  }
+                ],
+                "description": "A model that contains a new value to be set for a TaskField."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/data/tasks/{taskId}/fields": {
+      "get": {
+        "tags": [
+          "TaskField"
+        ],
+        "summary": "Retrieve All Task Field Values",
+        "description": "This endpoint has been replace with `tasks/{taskId}/fields/{fieldId}/values`",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task for which we want TaskField values",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskFieldValueDtoListAstroResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/data/tasks/{taskId}/files": {
+      "post": {
+        "tags": [
+          "TaskFile"
+        ],
+        "summary": "Upload Task File",
+        "description": "Uploads a file to a task.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project, a Task, or Home.  Files are maintained separately based on the location\r\nwhere the file was stored.\r\n            \r\nWhen you upload a File, please allow a few moments for the File to be processed and verified.\r\nProjectManager may reject File uploads that contain problems such as malware. Once a File has\r\ncompleted the upload the process, you may retrieve it using the DownloadFile API.\r\n            \r\nThis API returns a JSON response indicating success or failure.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The reference to the task",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/metadata": {
+      "put": {
+        "tags": [
+          "TaskMetadata"
+        ],
+        "summary": "Add Metadata",
+        "description": "Adds a metadata to a task",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "Task ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "isSystem",
+            "in": "query",
+            "description": "If metadata is for system or customer, isSystem = true is only of ProjectManager",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "isOverride",
+            "in": "query",
+            "description": "If false we merge with the keys",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The metadata",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TaskMetadataUpdateDto"
+                  }
+                ],
+                "description": "Task Metadata DTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "TaskMetadata"
+        ],
+        "summary": "Get task metadata",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "Task ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "isSystem",
+            "in": "query",
+            "description": "If metadata is for system or customer, isSystem = true is only of ProjectManager",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StringObjectDictionaryAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/metadata": {
+      "get": {
+        "tags": [
+          "TaskMetadata"
+        ],
+        "summary": "Get tasks by project ID and foreign key ID",
+        "parameters": [
+          {
+            "name": "foreignKey",
+            "in": "query",
+            "description": "Foreign Key ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "isSystem",
+            "in": "query",
+            "description": "If metadata is for system or customer, isSystem = true is only of ProjectManager",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskMetadataSearchDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/statuses": {
+      "get": {
+        "tags": [
+          "TaskStatus"
+        ],
+        "summary": "Retrieve Task Statuses",
+        "description": "Retrieves the list of TaskStatus levels for a specific Project within your Workspace.\r\n            \r\nA TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project to retrieve TaskStatuses",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStatusDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "TaskStatus"
+        ],
+        "summary": "Create TaskStatus",
+        "description": "Creates a new TaskStatus level for a specific Project within your Workspace.\r\n            \r\nA TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project for the new TaskStatus",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the new TaskStatus level to create within this Project",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TaskStatusCreateDto"
+                  }
+                ],
+                "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TaskStatus"
+        ],
+        "summary": "Update TaskStatus",
+        "description": "Updates an existing TaskStatus level for a specific Project within your Workspace.\r\n            \r\nA TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project for the new TaskStatus",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the existing TaskStatus level to update within this Project",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TaskStatusUpdateDto"
+                  }
+                ],
+                "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/projects/{projectId}/tasks/statuses/{taskStatusId}": {
+      "delete": {
+        "tags": [
+          "TaskStatus"
+        ],
+        "summary": "Delete TaskStatus",
+        "description": "The endpoint is used to delete a TaskStatus.\r\n            \r\nYou will not be able to delete a TaskStatus if there are tasks that have been assigned to this status level\r\nor if the TaskStatus is the default status level.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The unique identifier of the Project for the TaskStatus level to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "taskStatusId",
+            "in": "path",
+            "description": "The Id of the TaskStatus level to be removed.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/tasks/{taskId}/tags": {
+      "post": {
+        "tags": [
+          "TaskTag"
+        ],
+        "summary": "Replace TaskTags",
+        "description": "Replaces the existing TaskTags on a Task with a newly provided list of TaskTags.\r\n            \r\nA TaskTag is a connection between a Task and a Tag.  Each Task can have zero, one or many\r\nTaskTags associated with it.  TaskTags can be assigned and removed from the Task to help you\r\nclassify your Tasks and prioritize work.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task for which we will replace TaskTags",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The replacement list of TaskTags for this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NameDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TaskTag"
+        ],
+        "summary": "Add TaskTag to Task",
+        "description": "Add one or more new TaskTags to a Task.\r\n            \r\nA TaskTag is a connection between a Task and a Tag.  Each Task can have zero, one or many\r\nTaskTags associated with it.  TaskTags can be assigned and removed from the Task to help you\r\nclassify your Tasks and prioritize work.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task for which we will add TaskTags",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The new TaskTags to add to this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NameDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TaskTag"
+        ],
+        "summary": "Remove TaskTag from Task",
+        "description": "Removes one or more existing TaskTags from a Task.\r\n            \r\nA TaskTag is a connection between a Task and a Tag.  Each Task can have zero, one or many\r\nTaskTags associated with it.  TaskTags can be assigned and removed from the Task to help you\r\nclassify your Tasks and prioritize work.",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "description": "The unique identifier of the Task for which we will remove existing TaskTags",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The TaskTags to remove from this Task",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NameDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeSetStatusDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/integrations/teams/application": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Retrieve zip file for Teams Integrations",
+        "description": "Retrieves zip file for teams integrations.\r\n            \r\nThe Teams API is intended for use by ProjectManager and its business development partners.  Please\r\ncontact ProjectManager's sales team to request use of this API.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/timesheets": {
+      "post": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Create time entry",
+        "description": "Creates new time entry for given resource on given day.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TimesheetCreateRequestDto"
+                  }
+                ],
+                "description": "Payload to create time entry"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimesheetResponseDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Query TimeSheets",
+        "description": "Retrieve a list of TimeSheets that match an [OData formatted query](https://www.odata.org/).\r\n            \r\nTime Sheets is a list of times per task",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of records to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the given number of records and then returns $top records",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter the expression according to oData queries",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order collection by this field.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Include related data in the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimesheetDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/timesheets/{timesheetId}": {
+      "delete": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Delete time entry",
+        "description": "Delete time entry by id.",
+        "parameters": [
+          {
+            "name": "timesheetId",
+            "in": "path",
+            "description": "time entry id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Update time entry",
+        "description": "Updates a time entry by its unique identifier.",
+        "parameters": [
+          {
+            "name": "timesheetId",
+            "in": "path",
+            "description": "time entry id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TimesheetUpdateRequestDto"
+                  }
+                ],
+                "description": "Payload to update time entry"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimesheetResponseDtoAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/timesheets/admin-tasks": {
+      "get": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Returns active admin tasks that are used to report time",
+        "description": "Returns active admin tasks that are used to report time not related to work on projects. I.e. annual/sick leave etc",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimesheetAdminTypeDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/users/roles": {
+      "get": {
+        "tags": [
+          "UserRole"
+        ],
+        "summary": "Retrieve UserRoles",
+        "description": "Retrieves the list of UserRoles defined within this Workspace.\r\n            \r\nA UserRole is a name for a privilege level granted to a specific User.  The 'Global Admin'\r\nUserRole is granted to the owner of the Workspace, and this UserRole cannot be changed.\r\nYou can choose which UserRole applies to a User within your Workspace.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRoleDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/workspaces": {
+      "get": {
+        "tags": [
+          "WorkSpace"
+        ],
+        "summary": "Retrieve Workspaces",
+        "description": "Retrieve the list of Workspaces to which the currently logged on user has access.\r\n            \r\nA single User may have access to multiple Workspaces, although they can only be logged on\r\nto one Workspace at a time.  This API lists all Workspaces to which the currently logged on\r\nuser is entitled to access.  To determine which Workspace a user is currently logged on\r\nuse the `/api/data/me` endpoint.",
+        "parameters": [
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSpaceDtoListAstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data/workspaces/{organizationId}/join": {
+      "post": {
+        "tags": [
+          "WorkSpace"
+        ],
+        "summary": "Invite to Workspace",
+        "description": "Invite a specific user to join a Workspace to which the current user has administrator rights.\r\n            \r\nA single User may have access to multiple Workspaces, although they can only be logged on\r\nto one Workspace at a time.  This API lists all Workspaces to which the currently logged on\r\nuser is entitled to access.  To determine which Workspace a user is currently logged on\r\nuse the `/api/data/me` endpoint.\r\n            \r\nThis API allows you to invite a specific  an invitation to join a specific Workspace.",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "description": "The unique identifier of the Organization that you are inviting a User to joi",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-integration-name",
+            "in": "header",
+            "description": "The name of the calling system passed along as a header parameter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Information about the user which will receive the invitation",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/WorkSpaceJoinDto"
+                  }
+                ],
+                "description": "A Workspace represents a single business subscription to the ProjectManager.com service.  You\r\ncan be a member of multiple Workspaces.  Each Workspace is completely separate from all other\r\nWorkspaces and a user cannot log in to multiple Workspaces at the same time."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AstroResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiKeyCreateDto": {
+        "type": "object",
+        "properties": {
+          "tokenName": {
+            "type": "string",
+            "description": "Name of token",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a new api access key entity"
+      },
+      "ApiKeyDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Internal access token id",
+            "format": "uuid"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Created by user id",
+            "format": "uuid"
+          },
+          "expires": {
+            "type": "string",
+            "description": "Expires date",
+            "format": "date-time"
+          },
+          "apiKey": {
+            "type": "string",
+            "description": "Bearer Key",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of token",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents api access key entity"
+      },
+      "ApiKeyDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiKeyDto"
+              }
+            ],
+            "description": "Represents api access key entity",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ApiKeyDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "AssigneeUpsertDto": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the TaskAssignee to which work is being assigned.",
+            "format": "uuid"
+          },
+          "assignedEffort": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The new amount of effort to assign for this Resource. This value is measured in minutes.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "An AssigneeUpsert is a create-or-update process that will either create\r\na new assignment of effort to a TaskAssignee or update an existing effort\r\namount for an existing TaskAssignee."
+      },
+      "AstroError": {
+        "type": "object",
+        "properties": {
+          "technicalError": {
+            "type": "string",
+            "description": "A technical description of the error that occurred.  Not suitable for\r\ndisplay to end users.",
+            "nullable": true
+          },
+          "additionalErrors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If additional errors beyond the main error in `Message` occurred, they will be\r\nlisted here as individual messages.",
+            "nullable": true
+          },
+          "validationErrors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "This contains a dictionary of validation errors. The key is the name of the field",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "description": "A description of the error that occurred.  If your application has a user\r\ninterface, show this message to explain what went wrong.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about an error that occurred within the ProjectManager API."
+      },
+      "AstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nUse the `Success` value to determine if the API call succeeded.  If the API call failed, you can\r\nexamine the `Error` value to determine what went wrong."
+      },
+      "AuthenticationDto": {
+        "type": "object",
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "description": "Set to true if the connection was successful. False is not supported right now."
+          },
+          "authScheme": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Authenication scheme",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Set the connection status of an integration"
+      },
+      "AuthenticationStatusDto": {
+        "type": "object",
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "description": "Set to true if the connection was successful. False is not supported right now."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Set the connection status of an integration"
+      },
+      "ChangeSetDto": {
+        "type": "object",
+        "properties": {
+          "projectChangeSetId": {
+            "type": "integer",
+            "description": "Project Changeset ID",
+            "format": "int32"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Changeset",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Project ID",
+            "format": "uuid"
+          },
+          "version": {
+            "type": "integer",
+            "description": "Task version",
+            "format": "int32",
+            "nullable": true
+          },
+          "createBy": {
+            "type": "string",
+            "description": "Created by GUID",
+            "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "Created date",
+            "format": "date-time"
+          },
+          "actions": {
+            "type": "string",
+            "description": "Change set action",
+            "nullable": true
+          },
+          "changeSets": {
+            "type": "string",
+            "description": "Change set in json string",
+            "nullable": true
+          },
+          "processDate": {
+            "type": "string",
+            "description": "Processed date",
+            "format": "date-time",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "If process was successful",
+            "nullable": true
+          },
+          "exception": {
+            "type": "string",
+            "description": "Error message",
+            "nullable": true
+          },
+          "clientId": {
+            "type": "string",
+            "description": "UI ID",
+            "format": "uuid",
+            "nullable": true
+          },
+          "jsonData": {
+            "type": "string",
+            "description": "Changeset JSON data",
+            "nullable": true
+          },
+          "isUndo": {
+            "type": "boolean",
+            "description": "Is change set from UNDO"
+          },
+          "state": {
+            "type": "integer",
+            "description": "The state of the changeset",
+            "format": "int32"
+          },
+          "businessId": {
+            "type": "string",
+            "description": "Business ID",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "The project task change set"
+      },
+      "ChangeSetDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeSetDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ChangeSetStatusDto": {
+        "type": "object",
+        "properties": {
+          "changeSetId": {
+            "type": "string",
+            "description": "The unique identifier of this Changeset",
+            "format": "uuid"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the entity affected by this Changeset.  For example, if this\r\nChangeset was created for a Task, this value will be the unique identifier for the Task.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Returns the id of a specific ChangeSet"
+      },
+      "ChangeSetStatusDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeSetStatusDto"
+              }
+            ],
+            "description": "Returns the id of a specific ChangeSet",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ChangeSetStatusDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeSetStatusDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ConnectionSchemaDto": {
+        "type": "object",
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "description": "Whether or not the Integration Provider is connected."
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL to use to authenticate with the Integration Provider.",
+            "nullable": true
+          },
+          "authScheme": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MasterConnectionSchemeDto"
+            },
+            "description": "This class contains the AuthScheme to use to authenticate with the Integration Provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "This class contains the URL or AuthScheme to use to authenticate with the Integration Provider."
+      },
+      "ConnectionSchemaDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConnectionSchemaDto"
+              }
+            ],
+            "description": "This class contains the URL or AuthScheme to use to authenticate with the Integration Provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "CountryHolidayDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Holiday id",
+            "format": "uuid"
+          },
+          "date": {
+            "type": "string",
+            "description": "Date of holiday",
+            "format": "date"
+          },
+          "countryId": {
+            "type": "integer",
+            "description": "The Country Id the holiday is associated to",
+            "format": "int32"
+          },
+          "countryName": {
+            "type": "string",
+            "description": "The Country Name the holiday is associated to",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Country holiday entry"
+      },
+      "CountryHolidayDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CountryHolidayDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "CreateResourceSkillDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this Skill."
+          }
+        },
+        "additionalProperties": false,
+        "description": "This is a skill that can be allocated to a resource."
+      },
+      "CreateResourceTeamDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this Team."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A resource can be allocated a team."
+      },
+      "CreateTaskFieldDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the TaskField",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this TaskField.  Valid types are the following:\r\n* Text\r\n* Number\r\n* Date\r\n* Checkbox\r\n* Currency\r\n* DropdownSingle\r\n* DropdownMulti",
+            "nullable": true
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of options for use of this TaskField.  This is only valid if\r\nthe `Type` value is set to `Dropdown`.\r\n            \r\nWhen a custom TaskField of type `DropDown` is shown to a user in the\r\napplication, they will be able to choose one of the `Options` in this\r\nlist.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The short Id of this field - human readable identity",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project."
+      },
+      "DashboardSettingCreateDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique ID",
+            "format": "uuid",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID",
+            "format": "uuid",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "Either custom or one of DashboardType enum",
+            "nullable": true
+          },
+          "reactGridLayout": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReactGridLayoutDto"
+              }
+            ],
+            "description": "React grid layout configuration",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "User dashboard create or update dto"
+      },
+      "DashboardSettingDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique ID",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "description": "Either custom or one of DashboardType enum",
+            "nullable": true
+          },
+          "reactGridLayout": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReactGridLayoutDto"
+              }
+            ],
+            "description": "React grid layout configuration",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "The Dashboards API is intended for use by ProjectManager"
+      },
+      "DashboardSettingDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DashboardSettingDto"
+              }
+            ],
+            "description": "The Dashboards API is intended for use by ProjectManager",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "DashboardType": {
+        "enum": [
+          "MySummary",
+          "PortfolioSummary"
+        ],
+        "type": "string"
+      },
+      "DirectLinkDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The URL to use to authenticate with the Integration Provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "This class contains the URL to use to authenticate with the Integration Provider."
+      },
+      "DirectLinkDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DirectLinkDto"
+              }
+            ],
+            "description": "This class contains the URL to use to authenticate with the Integration Provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "DiscussionCommentCreateDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The text of the comment to add to the discussion, in Markdown format.\r\n            \r\nDiscussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges."
+      },
+      "DiscussionCommentCreateResponseDto": {
+        "type": "object",
+        "properties": {
+          "discussionCommentId": {
+            "type": "string",
+            "description": "The unique identifier of the discussion comment created.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges."
+      },
+      "DiscussionCommentCreateResponseDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiscussionCommentCreateResponseDto"
+              }
+            ],
+            "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "DiscussionCommentDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the discussion comment.",
+            "format": "uuid"
+          },
+          "discussionCommentId": {
+            "type": "string",
+            "description": "Obsolete - use Id instead",
+            "format": "uuid",
+            "deprecated": true
+          },
+          "text": {
+            "type": "string",
+            "description": "The text of the comment to add to the discussion, in Markdown format.\r\n            \r\nDiscussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges.",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string",
+            "description": "The unique ID of the resource that wrote this comment.",
+            "format": "uuid"
+          },
+          "authorName": {
+            "type": "string",
+            "description": "The unique ID of the resource that wrote this comment.",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp when the comment was created.",
+            "format": "date-time"
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp when the comment was modified, if it is different from the create date.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emoji": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscussionEmoji"
+            },
+            "description": "The list of emoji reactions to this discussion comment, if any.  This object will\r\nbe null if no emoji reactions have been recorded on this discussion comment.",
+            "nullable": true
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscussionCommentFileDto"
+            },
+            "description": "The list of files associated with this Comment, if any.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Tasks can have discussions attached to them.  These discussions can include text with simple\r\nformatting.  Discussion comments are formatted using [Markdown](https://www.markdownguide.org/)\r\nand users should be aware that HTML embedding is not permitted due to the risk of cross-site\r\nattacks and other embedding challenges."
+      },
+      "DiscussionCommentDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscussionCommentDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "DiscussionCommentFileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this file",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The url of the file which can be used for downloading",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DiscussionEmoji": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the emoji",
+            "nullable": true
+          },
+          "userIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The list of user IDs of the users who tagged these emoji",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A reaction to a specific comment within a discussion thread."
+      },
+      "ExportDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the export",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents an export queue object. Use this ID to check the status of the export."
+      },
+      "ExportDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExportDto"
+              }
+            ],
+            "description": "Represents an export queue object. Use this ID to check the status of the export.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ExportDueDateFilterDto": {
+        "type": "object",
+        "properties": {
+          "includeNoDueDate": {
+            "type": "boolean",
+            "description": "Include items without a due date",
+            "nullable": true
+          },
+          "includeOverdue": {
+            "type": "boolean",
+            "description": "Include items with a due date in the past",
+            "nullable": true
+          },
+          "includeToday": {
+            "type": "boolean",
+            "description": "Include items with a due date of today",
+            "nullable": true
+          },
+          "includeThisWeek": {
+            "type": "boolean",
+            "description": "Include items due within the current week",
+            "nullable": true
+          },
+          "includeNextWeek": {
+            "type": "boolean",
+            "description": "Include items due within the next week",
+            "nullable": true
+          },
+          "includeLater": {
+            "type": "boolean",
+            "description": "Include items due later",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Due Date Filter Settings"
+      },
+      "ExportPriorityFilterDto": {
+        "type": "object",
+        "properties": {
+          "isNone": {
+            "type": "boolean",
+            "description": "Include items with no priority",
+            "nullable": true
+          },
+          "isVeryLow": {
+            "type": "boolean",
+            "description": "Include items with very low priority",
+            "nullable": true
+          },
+          "isLow": {
+            "type": "boolean",
+            "description": "Include items with low priority",
+            "nullable": true
+          },
+          "isMedium": {
+            "type": "boolean",
+            "description": "Include items with medium priority",
+            "nullable": true
+          },
+          "isHigh": {
+            "type": "boolean",
+            "description": "Include items with high priority",
+            "nullable": true
+          },
+          "isVeryHigh": {
+            "type": "boolean",
+            "description": "Include items with very high priority",
+            "nullable": true
+          },
+          "isCritical": {
+            "type": "boolean",
+            "description": "Include items with critical priority",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Priority filter settings"
+      },
+      "FileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this file",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "If specified this file belongs to a project. The value is the id of  this project",
+            "format": "uuid",
+            "nullable": true
+          },
+          "taskId": {
+            "type": "string",
+            "description": "If specified, the file has been associated with this task.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "ownerId": {
+            "type": "string",
+            "description": "The reference for who uploaded the file",
+            "format": "uuid"
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "The UTC time the file was created.",
+            "format": "date-time"
+          },
+          "folderId": {
+            "type": "string",
+            "description": "A reference to the folder",
+            "format": "uuid"
+          },
+          "fileType": {
+            "type": "string",
+            "description": "The type of the file",
+            "nullable": true
+          },
+          "fileTypeLabel": {
+            "type": "string",
+            "description": "A user friendly label for the file type",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "description": "Size of the file in bytes",
+            "format": "int32"
+          },
+          "downloadPath": {
+            "type": "string",
+            "description": "Path to download the file",
+            "nullable": true
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Is the file in the trash can"
+          },
+          "type": {
+            "type": "string",
+            "description": "Defines the object type the file belongs to.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file",
+            "nullable": true
+          },
+          "entityOwnerId": {
+            "type": "string",
+            "description": "Id of owner of parent entity",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a file in project manager"
+      },
+      "FileDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FileDto"
+              }
+            ],
+            "description": "Represents a file in project manager",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "GlobalHolidayDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Holiday id",
+            "format": "uuid"
+          },
+          "date": {
+            "type": "string",
+            "description": "Date of holiday",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Global holiday entry"
+      },
+      "GlobalHolidayDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GlobalHolidayDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "HttpStatusCode": {
+        "enum": [
+          "Continue",
+          "SwitchingProtocols",
+          "Processing",
+          "EarlyHints",
+          "OK",
+          "Created",
+          "Accepted",
+          "NonAuthoritativeInformation",
+          "NoContent",
+          "ResetContent",
+          "PartialContent",
+          "MultiStatus",
+          "AlreadyReported",
+          "IMUsed",
+          "MultipleChoices",
+          "MovedPermanently",
+          "Found",
+          "SeeOther",
+          "NotModified",
+          "UseProxy",
+          "Unused",
+          "TemporaryRedirect",
+          "PermanentRedirect",
+          "BadRequest",
+          "Unauthorized",
+          "PaymentRequired",
+          "Forbidden",
+          "NotFound",
+          "MethodNotAllowed",
+          "NotAcceptable",
+          "ProxyAuthenticationRequired",
+          "RequestTimeout",
+          "Conflict",
+          "Gone",
+          "LengthRequired",
+          "PreconditionFailed",
+          "RequestEntityTooLarge",
+          "RequestUriTooLong",
+          "UnsupportedMediaType",
+          "RequestedRangeNotSatisfiable",
+          "ExpectationFailed",
+          "MisdirectedRequest",
+          "UnprocessableEntity",
+          "Locked",
+          "FailedDependency",
+          "UpgradeRequired",
+          "PreconditionRequired",
+          "TooManyRequests",
+          "RequestHeaderFieldsTooLarge",
+          "UnavailableForLegalReasons",
+          "InternalServerError",
+          "NotImplemented",
+          "BadGateway",
+          "ServiceUnavailable",
+          "GatewayTimeout",
+          "HttpVersionNotSupported",
+          "VariantAlsoNegotiates",
+          "InsufficientStorage",
+          "LoopDetected",
+          "NotExtended",
+          "NetworkAuthenticationRequired"
+        ],
+        "type": "string"
+      },
+      "IdDto": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier.  To determine the meaning of this unique identifier,\r\nsee the field to which this value is attached.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "When uploading a list of unique identifiers to the API, this data structure\r\nrepresents one individual unique identifier within the list."
+      },
+      "IntegrationAuthSetupDto": {
+        "type": "object",
+        "properties": {
+          "masterConnection": {
+            "type": "string",
+            "description": "Master Connection for provider",
+            "nullable": true
+          },
+          "userConnection": {
+            "type": "string",
+            "description": "UserConnection for Provider.",
+            "nullable": true
+          },
+          "masterConnectionSchema": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IntegrationConnectionSchemeObjectDto"
+            },
+            "description": "Master Connection scheme for Provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Integration Auth Setup for Provider."
+      },
+      "IntegrationCategoryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Integration Category.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "A friendly name for this Integration Category.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short identifier that uniquely identifies this Integration Category.",
+            "nullable": true
+          },
+          "integrationShortIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of short identifiers for Integrations available within this Integration Category.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about a category of Integrations available on the Marketplace."
+      },
+      "IntegrationCategoryDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationCategoryDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "IntegrationConnectionSchemeObjectDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the property",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the property",
+            "nullable": true
+          },
+          "sendToClient": {
+            "type": "boolean",
+            "description": "Send to the client true/false"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Master Connection Scheme for Providers"
+      },
+      "IntegrationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Integration",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The friendly name of this Integration",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of this Integration that can be shared with users",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short ID that uniquely identifies this Integration",
+            "nullable": true
+          },
+          "isMultiInstance": {
+            "type": "boolean",
+            "description": "True if this Integration allows multiple Instances.\r\n            \r\nAn example of a multi-Instance Integration is one that can be connected to many\r\ndifferent folders or channels within a remote application."
+          },
+          "config": {
+            "description": "Extra configuration metadata for this Instance.",
+            "nullable": true
+          },
+          "licenseSkus": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of SKUS for this Integration.",
+            "nullable": true
+          },
+          "instances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationInstanceDto"
+            },
+            "description": "For multi-Instance Integrations, this contains the list of IntegrationInstances.",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "True if this Integration is enabled for the current Workspace."
+          },
+          "authenticated": {
+            "type": "boolean",
+            "description": "True if the user has authenticated"
+          },
+          "autoEnabled": {
+            "type": "boolean",
+            "description": "True if the integration is auto-enabled"
+          },
+          "noAdminPermission": {
+            "type": "boolean",
+            "description": "No Admin Permission"
+          }
+        },
+        "additionalProperties": false,
+        "description": "The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API."
+      },
+      "IntegrationDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegrationDto"
+              }
+            ],
+            "description": "The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "IntegrationDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "IntegrationInstanceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this IntegrationInstance",
+            "format": "uuid"
+          },
+          "integrationShortId": {
+            "type": "string",
+            "description": "A short ID that uniquely identifies this IntegrationInstance",
+            "nullable": true
+          },
+          "enabledBy": {
+            "type": "string",
+            "description": "The unique identifier of the user who enabled this IntegrationInstance",
+            "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "Timestamp when this record was created",
+            "format": "date-time"
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "Timestamp when this record was most recently modified",
+            "format": "date-time"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "The id of the project manager project this instance is related to",
+            "format": "uuid"
+          },
+          "providerItemId": {
+            "type": "string",
+            "description": "The identifier in the integration provider, could be a reference to a file, task, project.",
+            "nullable": true
+          },
+          "providerItemName": {
+            "type": "string",
+            "description": "The name of the item in the integration provider.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API."
+      },
+      "IntegrationProviderDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Provider.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The friendly name of this Provider.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short ID that uniquely identifies this Provider.",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string",
+            "description": "A short summary of this Provider and their service.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A longer description of this Provider and their service.",
+            "nullable": true
+          },
+          "licenseSkus": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of available license SKUs for this Provider.",
+            "nullable": true
+          },
+          "categoryShortIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of category IDs that this Provider exists within.",
+            "nullable": true
+          },
+          "activated": {
+            "type": "boolean",
+            "description": "True if this Provider is available for use."
+          },
+          "authenticated": {
+            "type": "boolean",
+            "description": "True if this Provider requires authentication."
+          },
+          "integrations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDto"
+            },
+            "description": "The list of available Integrations for this Provider.",
+            "nullable": true
+          },
+          "authSetup": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegrationAuthSetupDto"
+              }
+            ],
+            "description": "The list of available AuthSetup for this Provider.",
+            "nullable": true
+          },
+          "createInWorkato": {
+            "type": "boolean",
+            "description": "Flag whether user/workspace needs to be setup in Workato"
+          }
+        },
+        "additionalProperties": false,
+        "description": "The Integrations API is intended for use by ProjectManager and its business\r\ndevelopment partners.  Please contact ProjectManager's sales team to request use of this API."
+      },
+      "IntegrationProviderDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationProviderDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "LicenseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this License.",
+            "format": "uuid"
+          },
+          "licenseSku": {
+            "type": "string",
+            "description": "The SKU code of this License, used for billing purposes.",
+            "nullable": true
+          },
+          "bundleSku": {
+            "type": "string",
+            "description": "The SKU code of the bundle of this License, used for billing purposes.",
+            "nullable": true
+          },
+          "optional": {
+            "type": "boolean",
+            "description": "True if this license is optional."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A License represents a subscription to a particular product or bundle of products\r\nwithin ProjectManager."
+      },
+      "LicenseDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LicenseDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "MasterConnectionSchemeDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the property",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the property",
+            "nullable": true
+          },
+          "sendToClient": {
+            "type": "boolean",
+            "description": "Send to the client true/false",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Master Connection Scheme for Providers"
+      },
+      "NameDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "A name.  To determine the meaning of this name, see the field to which this\r\nvalue is attached in the parent object."
+          }
+        },
+        "additionalProperties": false,
+        "description": "When uploading a list of names to an API, this data structure represents an\r\nindividual name within the list."
+      },
+      "NotificationDataDto": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Set if the notification is related to a task",
+            "format": "uuid",
+            "nullable": true
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Set if the notification is related to a project",
+            "format": "uuid",
+            "nullable": true
+          },
+          "taskShortId": {
+            "type": "string",
+            "description": "set if the notification is related to a task",
+            "nullable": true
+          },
+          "projectShortId": {
+            "type": "string",
+            "description": "set if the notification is related to a project",
+            "nullable": true
+          },
+          "projectName": {
+            "type": "string",
+            "description": "Name of the project the notification is related to",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "nullable": true
+          },
+          "senderFirstName": {
+            "type": "string",
+            "description": "Firstname of the person initiating the notification",
+            "nullable": true
+          },
+          "assigneeId": {
+            "type": "string",
+            "description": "Assignee for the notification",
+            "format": "uuid",
+            "nullable": true
+          },
+          "view": {
+            "type": "string",
+            "description": "View",
+            "nullable": true
+          },
+          "shareId": {
+            "type": "string",
+            "description": "Id for the shared item",
+            "nullable": true
+          },
+          "fileName": {
+            "type": "string",
+            "description": "Name of the file",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Contains the optional data associated with the notifcation."
+      },
+      "NotificationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this notification",
+            "format": "uuid"
+          },
+          "senderId": {
+            "type": "string",
+            "description": "The unique identifier of the sender of this notification",
+            "format": "uuid"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationDto"
+            },
+            "description": "If you received multiple notifications from the same user in a short period of time, they will be\r\ngrouped together.  For example, if you receive multiple notifications about users joining the same\r\nproject, they will be grouped together in the Children element.",
+            "nullable": true
+          },
+          "notificationType": {
+            "type": "string",
+            "description": "A friendly category or type for this notification",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "description": "Timestamp when the notification was sent",
+            "format": "date-time"
+          },
+          "subject": {
+            "type": "string",
+            "description": "User readable subject line for the notification",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "description": "User readable message content for the notification",
+            "nullable": true
+          },
+          "readDate": {
+            "type": "string",
+            "description": "Timestamp when the notification was acknowledged as read",
+            "format": "date-time",
+            "nullable": true
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationDataDto"
+              }
+            ],
+            "description": "A string containing JSON-encoded extra data for the notification",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically."
+      },
+      "NotificationResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationDto"
+            },
+            "description": "The most recent notifications pending for the current user.  If no notifications are pending for the current\r\nuser, this will be an empty array.  If there are more than 1,000 notifications this list may be truncated to\r\nonly the 1,000 most recent notifications.",
+            "nullable": true
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "The total number of pending notifications for the current user, including both read and unread.",
+            "format": "int32"
+          },
+          "unreadCount": {
+            "type": "integer",
+            "description": "The number of unread notifications for the current user.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically."
+      },
+      "NotificationResponseDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationResponseDto"
+              }
+            ],
+            "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "NotificationTimestampDto": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "description": "The timestamp of the notification action",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically."
+      },
+      "NotificationTimestampDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationTimestampDto"
+              }
+            ],
+            "description": "A notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "NotificationTotalCountDto": {
+        "type": "object",
+        "properties": {
+          "totalCount": {
+            "type": "integer",
+            "description": "The total number of notifications pending for the current user.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically."
+      },
+      "NotificationTotalCountDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationTotalCountDto"
+              }
+            ],
+            "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "NotificationUnreadCountDto": {
+        "type": "object",
+        "properties": {
+          "unreadCount": {
+            "type": "integer",
+            "description": "The number of unread notifications for the current user.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically."
+      },
+      "NotificationUnreadCountDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationUnreadCountDto"
+              }
+            ],
+            "description": "Information about notifications for the current user.\r\n            \r\nA notification represents a message sent to a user to inform them of relevant actions or events within their\r\nworkspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more\r\nthan 1,000 pending notifications some old notifications will be deleted automatically.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "PermissionOptionsDto": {
+        "type": "object",
+        "properties": {
+          "none": {
+            "type": "boolean",
+            "description": "If true, the users access can be removed"
+          },
+          "collaborate": {
+            "type": "boolean",
+            "description": "If true the user can be changed to collaborator"
+          },
+          "guest": {
+            "type": "boolean",
+            "description": "If true a user can be set as guest, a guest can only be Guest or None"
+          },
+          "editor": {
+            "type": "boolean",
+            "description": "If true the user can be changed to editor"
+          },
+          "manager": {
+            "type": "boolean",
+            "description": "If true the user can be changed to Manager"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Specifies the permissions a member can be changed to on a project.\r\nThis objects values can change based on the logged in user and the role they have."
+      },
+      "ProjectChangeStatusDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectChange.",
+            "format": "uuid"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if this ProjectChange was successfully applied.  If the ProjectChange has not been\r\napplied, this value is null.",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/State"
+              }
+            ],
+            "description": "A status flag that indicates the progress of the ProjectChange through resolution."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectChange is an individual edit that has been made to a project.  Since multiple users\r\ncan edit a project at the same time, individual ProjectChanges are applied in a sequential\r\nfashion. If a ProjectChange causes a conflict or cannot be applied, it will be rejected.\r\nYou can examine a ProjectChange to determine its conflict resolution status."
+      },
+      "ProjectChangeStatusDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectChangeStatusDto"
+              }
+            ],
+            "description": "A ProjectChange is an individual edit that has been made to a project.  Since multiple users\r\ncan edit a project at the same time, individual ProjectChanges are applied in a sequential\r\nfashion. If a ProjectChange causes a conflict or cannot be applied, it will be rejected.\r\nYou can examine a ProjectChange to determine its conflict resolution status.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectChargeCodeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ChargeCode",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ChargeCode",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ChargeCode is a code used to identify costs within your Projects.  Each ChargeCode has\r\na name and a unique identifier.  ChargeCodes are defined per Workspace and are shared\r\namong Projects."
+      },
+      "ProjectChargeCodeDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectChargeCodeDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectCreateAccessDto": {
+        "type": "object",
+        "properties": {
+          "everyone": {
+            "type": "boolean",
+            "description": "If set to true every user will get access to this project"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectCreateAccessMemberDto"
+            },
+            "description": "If everyone is set to false the list of members will be used to give people access",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Specify who has access to a newly created project"
+      },
+      "ProjectCreateAccessMemberDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "Member's id",
+            "format": "uuid"
+          },
+          "permission": {
+            "type": "string",
+            "description": "Member's role in the project",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents project member that have access to new project"
+      },
+      "ProjectCreateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the Project.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the Project",
+            "nullable": true
+          },
+          "folderId": {
+            "type": "string",
+            "description": "The unique identifier of the folder of this project, or null if not assigned.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "projectAccess": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectCreateAccessDto"
+              }
+            ],
+            "description": "If you wish to grant access to this Project to a selected list of people during creation,\r\nprovide a list of ProjectMembers here.  If you do not specify anyone, this Project will\r\nbe available to only yourself.",
+            "nullable": true
+          },
+          "customerId": {
+            "type": "string",
+            "description": "The unique identifier of the customer for this project, or null if not customer specific",
+            "format": "uuid",
+            "nullable": true
+          },
+          "managerId": {
+            "type": "string",
+            "description": "The unique identifier of the manager of this project, or null if not assigned.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "chargeCodeId": {
+            "type": "string",
+            "description": "The unique identifier of the ChargeCode for this Project, if one has been selected.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "statusId": {
+            "type": "string",
+            "description": "The ProjectStatus chosen for this Project, if one has been selected.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priorityId": {
+            "type": "string",
+            "description": "The ProjectPriority level of this Project, if one has been selected.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "The default hourly rate for work on this Project.  This rate will be used\r\nif an assignee working on this Project does not have an hourly rate configured\r\nin their profile.",
+            "format": "double",
+            "nullable": true
+          },
+          "budget": {
+            "type": "number",
+            "description": "The proposed budget for this Project.",
+            "format": "double",
+            "nullable": true
+          },
+          "statusUpdate": {
+            "type": "string",
+            "description": "Contains an optional status update for Projects that can be used to summarize\r\nthe status of multiple Projects at a glance.\r\n            \r\nYou can edit the StatusUpdate field on the Portfolio page of the application.",
+            "nullable": true
+          },
+          "template": {
+            "type": "boolean",
+            "description": "True if this Project is a template that will be reused as a framework\r\nfor future Projects.\r\n            \r\nYou can save a Project as a template and reuse it in the future for creating\r\nadditional Projects.  If this Project is a template, set this to `true` and this\r\ntemplate will be available to choose from when creating a new Project within the\r\napplication."
+          },
+          "templateId": {
+            "type": "string",
+            "description": "When creating a Project, you can optionally specify a Template to use to construct\r\nthe Project using a collection of pre-designed Tasks.\r\n            \r\nSpecifying a value in the TemplateId field will copy default settings for Tasks from\r\nyour template Project into the newly created Project.\r\n            \r\nThis field does not support custom templates.  You must choose from a list of\r\nProjectManager-supplied templates.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "The target planned completion date for this Project, or null if one has\r\nnot been selected.  This value can be updated in the Project Settings\r\npage or the Portfolio Project page within the application.",
+            "format": "date",
+            "nullable": true
+          },
+          "favorite": {
+            "type": "boolean",
+            "description": "True if this Project is marked as favorite for current user",
+            "nullable": true
+          },
+          "taskStatusCreate": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskStatusCreateDto"
+            },
+            "description": "Create default task status upfront",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.\r\n            \r\nFields that cannot be selected during a CreateProject API call are not visible on this\r\ndata model."
+      },
+      "ProjectCustomerDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectCustomer",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectCustomer",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectCustomer is a code used to identify costs within your Projects.  Each\r\nProjectCustomer has a name and a unique identifier.  ChargeCodes are defined per\r\nWorkspace and are shared among Projects."
+      },
+      "ProjectCustomerDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectCustomerDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the Project.  This value is set by the system and cannot\r\nbe set with a CreateProject or changed with an UpdateProject call.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the Project.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the Project",
+            "nullable": true
+          },
+          "shortCode": {
+            "type": "string",
+            "description": "A shortened name that will be used when reporting on Projects.  This short\r\nname can be edited in the Project Settings page within the application\r\nand can be any text you wish.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short identifier that uniquely identifies this Project within your Workspace\r\nusing a single letter followed by a number.  This code can be used for APIs\r\nthat accept Project unique identifiers.\r\n            \r\nYou can observe the short ID within the application by observing the URL of\r\nthe page you visit when you click on this project.  The page's URL will appear\r\nin the form `https://pm.app.projectmanager.com/project/board/D16` - in this\r\nexample, the `ShortId` is `D16`.\r\n            \r\nThis code is automatically assigned for you and cannot be changed.",
+            "nullable": true
+          },
+          "folder": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectFolderDto"
+              }
+            ],
+            "description": "If this Project is grouped within a ProjectFolder, this contains the ProjectFolder information.",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectStatusDto"
+              }
+            ],
+            "description": "The ProjectStatus chosen for this Project.",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The earliest planned or actual start date of tasks on the project.\r\n            \r\nThis field is calculated automatically and cannot be changed.",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "description": "The latest planned or actual finish date of tasks on the project.\r\n            \r\nThis field is calculated automatically and cannot be changed.",
+            "format": "date",
+            "nullable": true
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "The target planned completion date for this Project, or null if one has\r\nnot been selected.  This value can be updated in the Project Settings\r\npage or the Portfolio Project page within the application.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedStartDate": {
+            "type": "string",
+            "description": "A calculated field of the estimated date on which this Project is\r\nexpected to start.\r\n            \r\nThis date is calculated based on the earliest estimated start date for\r\na Task within this Project. This value is null if no Tasks have an\r\nestimated start date within this Project.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedFinishDate": {
+            "type": "string",
+            "description": "A calculated field of the estimated date on which this Project is\r\nexpected to finish.\r\n            \r\nThis date is calculated based on the latest planned finish date for a\r\nTask within this Project. This value is null if no Tasks have an\r\nestimated finish date within this Project.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualStartDate": {
+            "type": "string",
+            "description": "A calculated field of the actual date on which this Project started.\r\n            \r\nThis date is calculated based on the earliest actual start date for a\r\nTask within this Project. This value is null if no Tasks have an actual\r\nstart date within this Project.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualFinishDate": {
+            "type": "string",
+            "description": "A calculated field of the actual date on which this Project finished.\r\n\r\n This date is calculated based on the latest actual finish date for a\r\n Task within this Project. This value is null if no Tasks have an\r\n actual finish date within this Project.",
+            "format": "date",
+            "nullable": true
+          },
+          "priority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectPriorityDto"
+              }
+            ],
+            "description": "The ProjectPriority level of this Project, if defined.",
+            "nullable": true
+          },
+          "chargeCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectChargeCodeDto"
+              }
+            ],
+            "description": "The ChargeCode of this Project, if defined.",
+            "nullable": true
+          },
+          "manager": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectManagerDto"
+              }
+            ],
+            "description": "Information about the manager of this project, if one has been assigned.",
+            "nullable": true
+          },
+          "customer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectCustomerDto"
+              }
+            ],
+            "description": "Information about the manager of this project, if one has been specified.",
+            "nullable": true
+          },
+          "budget": {
+            "type": "number",
+            "description": "The proposed budget for this Project.",
+            "format": "double",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "The default hourly rate for work on this Project.  This rate will be used\r\nif an assignee working on this Project does not have an hourly rate configured\r\nin their profile.",
+            "format": "double",
+            "nullable": true
+          },
+          "statusUpdate": {
+            "type": "string",
+            "description": "Contains an optional status update for Projects that can be used to summarize\r\nthe status of multiple Projects at a glance.\r\n            \r\nYou can edit the StatusUpdate field on the Portfolio page of the application.",
+            "nullable": true
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when the Project was most recently modified.\r\n            \r\nThis field is automatically determined by the system when this Project is modified\r\nand cannot be directly changed by the user.",
+            "format": "date-time"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when the Project was created.\r\n            \r\nThis field is automatically determined by the system when this Project is created\r\nand cannot be changed by the user.",
+            "format": "date-time"
+          },
+          "isTemplate": {
+            "type": "boolean",
+            "description": "True if this Project is a template that will be reused as a framework\r\nfor future Projects."
+          },
+          "favorite": {
+            "type": "boolean",
+            "description": "True if this Project is marked as favorite for current user"
+          },
+          "creationTemplateId": {
+            "type": "string",
+            "description": "The TemplateId that this project was created from.\r\nWill be null if no template was selected at project creation.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectMemberDto"
+            },
+            "description": "The members of the project",
+            "nullable": true
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Obsolete - use FieldValues instead",
+            "nullable": true,
+            "deprecated": true
+          },
+          "fieldValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectFieldValueDto"
+            },
+            "description": "Project fields array with values",
+            "nullable": true
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectFileDto"
+            },
+            "description": "The list of files associated with this Project, if any.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          },
+          "percentComplete": {
+            "type": "integer",
+            "description": "The percentage of the project tasks completed",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project."
+      },
+      "ProjectDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectDto"
+              }
+            ],
+            "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectFieldCreateDto": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of this Field"
+          },
+          "type": {
+            "enum": [
+              "string",
+              "number",
+              "date",
+              "bool",
+              "currency",
+              "dropdown-single",
+              "dropdown-multi"
+            ],
+            "type": "string",
+            "description": "The type of the Field.\r\n            \r\nAttempting to create a field with any Type other than these will\r\nreturn an error.\r\n            \r\nFor Dropdown Field types, specify the list of choices in the `Options`\r\nfield. \r\n \r\n Valid options are: \n * string \n * number \n * date \n * bool \n * currency \n * dropdown-single \n * dropdown-multi"
+          },
+          "shortId": {
+            "pattern": "^[a-zA-Z0-9_]+$",
+            "type": "string",
+            "description": "The short Id of this field - human readable identity",
+            "nullable": true
+          },
+          "options": {
+            "minLength": 2,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of options for use of this ProjectField.  This is only valid if\r\nthe `Type` value is set to `Dropdown`.\r\n            \r\nWhen a custom TaskField of type `DropDown` is shown to a user in the\r\napplication, they will be able to choose one of the `Options` in this\r\nlist.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace."
+      },
+      "ProjectFieldDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Field",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Field",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the Field.  Valid types are the following:\r\n* Text\r\n* Number\r\n* Date\r\n* Currency\r\n* Dropdown\r\n            \r\nAttempting to create a field with any Type other than these will\r\nreturn an error.\r\n            \r\nFor Dropdown Field, specify the list of choices in the `Options`\r\nfield.",
+            "nullable": true
+          },
+          "entityType": {
+            "type": "string",
+            "description": "The entity type of the Field, either `projects` or `tasks`.",
+            "nullable": true
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of options for use of this Field.  This is only valid if\r\nthe `Type` value is set to `Dropdown`.\r\n            \r\nWhen a custom Field of type `DropDown` is shown to a user in the\r\napplication, they will be able to choose one of the `Options` in this\r\nlist.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The short Id of this field - human readable identity",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents either a ProjectField or a TaskField, depending on the value of the\r\n`EntityType` for this object.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project."
+      },
+      "ProjectFieldDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectFieldDto"
+              }
+            ],
+            "description": "Represents either a ProjectField or a TaskField, depending on the value of the\r\n`EntityType` for this object.\r\n            \r\nA ProjectField is a custom field defined within your Workspace.  You can define ProjectFields\r\nfor any integration purpose that is important to your business.  Each ProjectField has a data\r\ntype as well as options in how it is handled.  ProjectFields can be edited for each Project\r\nwithin your Workspace.\r\n            \r\nA TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectFieldDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectFieldDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectFieldValueDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Project Field.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The unique Short Id of this Project Field.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Project Field.",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this Project Field.  Valid types are the following:\r\n* Text\r\n* Number\r\n* Date\r\n* Checkbox\r\n* Currency\r\n* Dropdown",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "description": "The value currently set for this Project Field Value.",
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was created.",
+            "format": "date-time"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was last modified.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A model that contains the value for a ProjectField."
+      },
+      "ProjectFieldValueDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectFieldValueDto"
+              }
+            ],
+            "description": "A model that contains the value for a ProjectField.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectFieldValueDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectFieldValueDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectFileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this file",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The url of the file which can be used for downloading",
+            "nullable": true
+          },
+          "task": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectFileTaskDto"
+              }
+            ],
+            "description": "The project task that this file relates to.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          },
+          "folder": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectFileFolderDto"
+              }
+            ],
+            "description": "The folder that this file relates to.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectFileFolderDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Folder.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Folder.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Folder is a named storage location that can contain Files."
+      },
+      "ProjectFileTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Task.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short ID that can be used to refer to this Task.  This short ID is\r\nguaranteed to be unique within your Workspace.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Task.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectFolderDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectFolder.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectFolder.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectFolder is a named storage location that can contain Projects."
+      },
+      "ProjectFolderDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectFolderDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectManagerDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectManager",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectManager",
+            "nullable": true
+          },
+          "initials": {
+            "type": "string",
+            "description": "Manager initials",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "description": "Avatar's url",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectManager is a person who manages a Project."
+      },
+      "ProjectMemberDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the user of this ProjectMember.",
+            "format": "uuid"
+          },
+          "initials": {
+            "type": "string",
+            "description": "the initials of the user",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the user",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "description": "Avatar URL",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "description": "The role of the user in the project\r\nObsolete use Permission instead",
+            "nullable": true,
+            "deprecated": true
+          },
+          "permission": {
+            "type": "string",
+            "description": "The current permission of the user",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The color for their avatar",
+            "nullable": true
+          },
+          "permissionOptions": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PermissionOptionsDto"
+              }
+            ],
+            "description": "Specifies the permissions that you can set against the project member. This changes based on who is logged in and the role they have.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectMember is a user who can collaborate on a Project.  You can control\r\npermissions for what each ProjectMember can do and how they can interact with\r\nthe Project using this model."
+      },
+      "ProjectMemberDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectMemberDto"
+              }
+            ],
+            "description": "A ProjectMember is a user who can collaborate on a Project.  You can control\r\npermissions for what each ProjectMember can do and how they can interact with\r\nthe Project using this model.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectMemberDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectMemberDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectMemberRoleDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectPermission"
+              }
+            ],
+            "description": "Role to apply"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Dto To Describe a ProjectMember Role"
+      },
+      "ProjectPermission": {
+        "enum": [
+          "Guest",
+          "Collaborate",
+          "Editor",
+          "Manager"
+        ],
+        "type": "string"
+      },
+      "ProjectPriorityDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectPriority.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectPriority.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectPriority is a named priority level used by your business to determine how to decide\r\nwhich Tasks are the most important.  You can name your ProjectPriority levels anything you like\r\nand you can reorganize the order of the ProjectPriority levels at any time."
+      },
+      "ProjectPriorityDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectPriorityDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectStatusDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectStatus.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectStatus.",
+            "nullable": true
+          },
+          "isDeleted": {
+            "type": "boolean",
+            "description": "Is this a deleted status"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectStatus is a named condition used by your business to categorize the completion level\r\nof Tasks and Projects within your Workspace.  You can name your ProjectStatus levels anything\r\nyou like and you can reorganize the order of the ProjectPriority levels at any time."
+      },
+      "ProjectStatusDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectStatusDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectTemplateCategoryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectTemplate Category.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "A friendly name for this ProjectTemplate Category.",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "description": "The overall order of this ProjectTemplate Category",
+            "format": "int32"
+          },
+          "templates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTemplateDto"
+            },
+            "description": "A list of templates in this category",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about a Category of ProjectTemplates."
+      },
+      "ProjectTemplateCategoryDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTemplateCategoryDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectTemplateDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ProjectTemplate.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ProjectTemplate.\r\n            \r\nName can de used as a unique text reference for Project Templates.",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of this ProjectTemplate.\r\n            \r\nTitle can be used as a description text for Project Templates.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The full text description of this ProjectTemplate.",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon path for this ProjectTemplate.",
+            "nullable": true
+          },
+          "previewImage": {
+            "type": "string",
+            "description": "The preview image path for this ProjectTemplate.",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "description": "The overall order of this ProjectTemplate.\r\n            \r\nThis order only applies to non-Custom ProjectTemplates",
+            "format": "int32"
+          },
+          "isCustom": {
+            "type": "boolean",
+            "description": "Is this ProjectTemplate a custom template.\r\n            \r\nCustom templates are Templates that have been created from existing\r\nProject definitions."
+          },
+          "defaultView": {
+            "type": "string",
+            "description": "The web default view of the template.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ProjectTemplate is a named document that contains default Project details.\r\n            \r\nProject Templates are defined for the system and are shared among Projects."
+      },
+      "ProjectTemplateDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectTemplateDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ProjectUpdateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the Project.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the Project",
+            "nullable": true
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "The target planned completion date for this Project, or null if one has\r\nnot been selected.  This value can be updated in the Project Settings\r\npage or the Portfolio Project page within the application.",
+            "format": "date",
+            "nullable": true
+          },
+          "folderId": {
+            "type": "string",
+            "description": "To move this Project into a ProjectFolder, set this to the unique identifier of the\r\nProjectFolder.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "customerId": {
+            "type": "string",
+            "description": "To assign this Project to a ProjectCustomer, set this to the unique identifier of the\r\nProjectCustomer.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "managerId": {
+            "type": "string",
+            "description": "To assign this Project to a ProjectManager, set this to the unique identifier of the\r\nProjectManager.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "chargeCodeId": {
+            "type": "string",
+            "description": "To set the ChargeCode for this Project, set this to the unique identifier of the\r\nChargeCode to use for this Project.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "statusId": {
+            "type": "string",
+            "description": "To change the ProjectStatus of this Project, set this to the unique identifier of the\r\nProjectStatus.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priorityId": {
+            "type": "string",
+            "description": "To change the ProjectPriority of this Project, set this to the unique identifier of the\r\nProjectPriority.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "To change the hourly rate of this Project, set this to the new amount.",
+            "format": "double",
+            "nullable": true
+          },
+          "budget": {
+            "type": "number",
+            "description": "To change the budget of this Project, set this to the new amount.",
+            "format": "double",
+            "nullable": true
+          },
+          "statusUpdate": {
+            "type": "string",
+            "description": "To update the Project's status text, set this to the new status text.",
+            "nullable": true
+          },
+          "favorite": {
+            "type": "boolean",
+            "description": "Mark this project as favorite for the logged in user.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project.\r\n            \r\nFields that cannot be modified during an UpdateProject call are not visible on this data\r\nmodel."
+      },
+      "ProjectVersionChangeDataDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "nullable": true
+          },
+          "property": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "restoreVersion": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectVersionDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the project version.",
+            "format": "uuid"
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version of the Project",
+            "format": "int32"
+          },
+          "initials": {
+            "type": "string",
+            "description": "the initials of the user",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the user",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "description": "Avatar URL",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The color for their avatar",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "description": "Version datetime",
+            "format": "date-time"
+          },
+          "userId": {
+            "type": "string",
+            "description": "The unique identifier of user who created backup",
+            "format": "uuid"
+          },
+          "groupId": {
+            "type": "string",
+            "description": "The group version belongs to",
+            "format": "uuid",
+            "nullable": true
+          },
+          "changeData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectVersionChangeDataDto"
+              }
+            ],
+            "description": "Subset of the changes related to this ProjectVersion",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectVersionDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectVersionDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ReactGridLayoutDto": {
+        "type": "object",
+        "properties": {
+          "lg": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactGridLayoutItemDto"
+            },
+            "description": "Used for large screen size (1200)",
+            "nullable": true
+          },
+          "md": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactGridLayoutItemDto"
+            },
+            "description": "Used for medium screen size (996)",
+            "nullable": true
+          },
+          "sm": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactGridLayoutItemDto"
+            },
+            "description": "Used for small screen size (768)",
+            "nullable": true
+          },
+          "xs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactGridLayoutItemDto"
+            },
+            "description": "Used for extra small screen size (480)",
+            "nullable": true
+          },
+          "xxs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactGridLayoutItemDto"
+            },
+            "description": "Used for super small screen size (0)",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A setting for react grid layout sizes"
+      },
+      "ReactGridLayoutItemDto": {
+        "type": "object",
+        "properties": {
+          "w": {
+            "type": "integer",
+            "description": "Width",
+            "format": "int32"
+          },
+          "h": {
+            "type": "integer",
+            "description": "Height",
+            "format": "int32"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X position",
+            "format": "int32"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y position",
+            "format": "int32"
+          },
+          "i": {
+            "type": "string",
+            "description": "ID",
+            "nullable": true
+          },
+          "moved": {
+            "type": "boolean",
+            "description": "Moved indicator"
+          },
+          "static": {
+            "type": "boolean",
+            "description": "If true, equal to `isDraggable: false, isResizable: false`"
+          }
+        },
+        "additionalProperties": false,
+        "description": "React grid layout item object"
+      },
+      "ResourceApproverDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ResourceApprover",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ResourceApprover",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "When managing users, you can choose who will approve a person's Timesheets. This\r\nis a ResourceApprover.  You can specify this person within the Resource object."
+      },
+      "ResourceCreateDto": {
+        "required": [
+          "firstName"
+        ],
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The first name of the person Resource.\r\n            \r\nApplies to personnel Resources only."
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address of this Resource.",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "minimum": 0,
+            "type": "number",
+            "description": "The basic hourly rate for this Resource.",
+            "format": "double",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "description": "The phone number associated with this Resource.",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "description": "The city where this Resource is located.",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "description": "The state or region where this Resource is located.  This value is not constrained\r\nto a list of known states or regions.",
+            "nullable": true
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "A text field indicating the country in which this Resource is located.\r\nThis value must be one of the following: US, NZ, AU.",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Free-form text notes about this Resource.  You may use this field to store extra\r\ninformation about the Resource.",
+            "nullable": true
+          },
+          "roleId": {
+            "type": "string",
+            "description": "The Role Id associated with this Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "teamIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The list of ResourceTeams to which this Resource belongs.",
+            "nullable": true
+          },
+          "skillIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The list of ResourceSkills possessed by this Resource.",
+            "nullable": true
+          },
+          "colorName": {
+            "type": "string",
+            "description": "Collaboration Color for this resource.\r\n            \r\neg. teal, cyan, lightblue, blurple, purple, pink, orange, gray",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "description": "Deprecated - this property is no longer being used.  Please pass in Country data on\r\nthe CountryCode property.\r\n            \r\nA text field indicating the country in which this Resource is located.  This value\r\nis not constrained to the list of known ISO 3166 country names or codes.",
+            "nullable": true,
+            "deprecated": true
+          },
+          "role": {
+            "type": "string",
+            "description": "Deprecated - this property is no longer being used.  Please pass in Role data on\r\nthe RoleId property\r\n            \r\nThe Role privileges associated with this Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true,
+            "deprecated": true
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Deprecated - this property is no longer being used.  Please pass in Team data on\r\nthe TeamIds property\r\n            \r\nThe list of ResourceTeams to which this Resource belongs.",
+            "nullable": true,
+            "deprecated": true
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Deprecated - this property is no longer being used.  Please pass in Skill data on\r\nthe SkillIds property\r\n            \r\nThe list of ResourceSkills possessed by this Resource.",
+            "nullable": true,
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "ResourceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Resource.",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "If this Resource is a person who can log on to ProjectManager.com, this value should be the email address of the\r\nperson.  If this Resource is not a person, but you wish to receive email alerts for usage of this Resource, you\r\ncan also add an email address here and notifications will be sent when this Resource is used.\r\n            \r\nOtherwise this value should be `null`.",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "The basic hourly rate for this Resource.",
+            "format": "double",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "description": "The phone number associated with this Resource.",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "description": "The city where this Resource is located.",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "description": "The state or region where this Resource is located.  This value is not constrained\r\nto a list of known states or regions.",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "description": "A text field indicating the country in which this Resource is located.  This value\r\nis not constrained to the list of known ISO 3166 country names or codes.",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Free-form text notes about this Resource.  You may use this field to store extra\r\ninformation about the Resource.",
+            "nullable": true
+          },
+          "approver": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceApproverDto"
+              }
+            ],
+            "description": "When managing users, you can choose who will approve a person's Timesheets. This\r\nis a ResourceApprover.  You can specify this person within the Resource object.",
+            "nullable": true
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceTeamDto"
+            },
+            "description": "The list of ResourceTeams to which this Resource belongs.",
+            "nullable": true
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceSkillDto"
+            },
+            "description": "The list of ResourceSkills possessed by this Resource.",
+            "nullable": true
+          },
+          "onlineDateTime": {
+            "type": "string",
+            "description": "The last time when this Resource was online.\r\n            \r\nApplies to personnel Resources only.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "description": "The Role privileges associated with this Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "True if this Resource is currently active and valid.  If this value is false,\r\nthis Resource is considered to be deactivated and not available for further use.\r\n            \r\nFor personnel Resources, setting this value to False will make this user unable\r\nto access this Workspace."
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "The date this resource was created",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Set to a unique identifier of the user who created this Resource.",
+            "format": "uuid"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "description": "The date this resource was last modified",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "description": "Set to a unique identifier of the user who last modified this Resource.",
+            "format": "uuid"
+          },
+          "colorName": {
+            "type": "string",
+            "description": "Collaboration Color for this resource.\r\n            \r\neg. teal, cyan, lightblue, blurple, purple, pink, orange, gray",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "Read only Hex code of the ColorName",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "ResourceDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceDto"
+              }
+            ],
+            "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceHolidayDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Holiday id",
+            "format": "uuid"
+          },
+          "date": {
+            "type": "string",
+            "description": "Date of holiday",
+            "format": "date"
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "Resource id holoday associated to",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Resource holiday entry"
+      },
+      "ResourceHolidayDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceHolidayDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceSkillDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ResourceSkill",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ResourceSkill",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ResourceSkill is a capability possessed by this Resource that can be used to\r\ndetermine appropriate assignments.  Some Resources may have ResourceSkills that\r\nare in high demand and some Tasks may have a requirement for Resources with particular\r\nResourceSkills."
+      },
+      "ResourceSkillDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceSkillDto"
+              }
+            ],
+            "description": "A ResourceSkill is a capability possessed by this Resource that can be used to\r\ndetermine appropriate assignments.  Some Resources may have ResourceSkills that\r\nare in high demand and some Tasks may have a requirement for Resources with particular\r\nResourceSkills.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceSkillDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceSkillDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceTeamDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this ResourceTeam",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this ResourceTeam",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A ResourceTeam is a group of Resources that can be referred to as a group.  You can use a\r\nResourceTeam as a shortcut to quickly assign or allocate multiple Resources quickly."
+      },
+      "ResourceTeamDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceTeamDto"
+              }
+            ],
+            "description": "A ResourceTeam is a group of Resources that can be referred to as a group.  You can use a\r\nResourceTeam as a shortcut to quickly assign or allocate multiple Resources quickly.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceTeamDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceTeamDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "ResourceUpdateDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address of this Resource.\r\n            \r\nNote that this email cannot be changed once it has been assigned.",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "minimum": 0,
+            "type": "number",
+            "description": "The basic hourly rate for this Resource.",
+            "format": "double",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "description": "The phone number associated with this Resource.",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "description": "The city where this Resource is located.",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "description": "The state or region where this Resource is located.  This value is not constrained\r\nto a list of known states or regions.",
+            "nullable": true
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "A text field indicating the country in which this Resource is located.\r\nThis value must be one of the following: US, NZ, AU.",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Free-form text notes about this Resource.  You may use this field to store extra\r\ninformation about the Resource.",
+            "nullable": true
+          },
+          "roleId": {
+            "type": "string",
+            "description": "The Role Id associated with this Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "teamIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The list of ResourceTeams to which this Resource belongs.",
+            "nullable": true
+          },
+          "skillIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The list of ResourceSkills possessed by this Resource.",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Active/Inactive the Resource.",
+            "nullable": true
+          },
+          "approverId": {
+            "type": "string",
+            "description": "The Approver Id associated with this Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "colorName": {
+            "type": "string",
+            "description": "Collaboration Color for this resource.\r\n            \r\neg. teal, cyan, lightblue, blurple, purple, pink, orange, gray",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "ResourcesCreateDto": {
+        "type": "object",
+        "properties": {
+          "projectIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "When creating a user they will also be added to the projectIds specified. If null or empty the user will be invited but no access will be given to any projects.",
+            "nullable": true
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceCreateDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "ResourcesDto": {
+        "type": "object",
+        "properties": {
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceDto"
+            },
+            "nullable": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserError"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "ResourcesDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourcesDto"
+              }
+            ],
+            "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "RiskExportProgressFilterDto": {
+        "type": "object",
+        "properties": {
+          "isOpen": {
+            "type": "boolean",
+            "description": "Include risks that are open",
+            "nullable": true
+          },
+          "isClosed": {
+            "type": "boolean",
+            "description": "Include risks that are closed",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Risk Progress Filter Settings"
+      },
+      "RiskExportSettingsDto": {
+        "required": [
+          "columns"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "the name used by the export",
+            "nullable": true
+          },
+          "format": {
+            "enum": [
+              "Csv",
+              "excel"
+            ],
+            "type": "string",
+            "description": "Format to export to, currently csv and excel are supported \r\n \r\n Valid options are: \n * Csv \n * excel",
+            "nullable": true
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of column names to export"
+          },
+          "orderBy": {
+            "enum": [
+              "name",
+              "createDate",
+              "assignees",
+              "dueDate",
+              "impact",
+              "level",
+              "likelihood",
+              "openClosed",
+              "priority",
+              "response",
+              "tags",
+              "description",
+              "resolution"
+            ],
+            "type": "string",
+            "description": "Which column should be used to order the data \r\n \r\n Valid options are: \n * name \n * createDate \n * assignees \n * dueDate \n * impact \n * level \n * likelihood \n * openClosed \n * priority \n * response \n * tags \n * description \n * resolution",
+            "nullable": true
+          },
+          "orderDirection": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string",
+            "description": "Specifies the direction of the order. Valid values are \"asc\" and \"desc\" \r\n \r\n Valid options are: \n * asc \n * desc",
+            "nullable": true
+          },
+          "timeZoneOffset": {
+            "type": "integer",
+            "description": "Timezone offset in minutes",
+            "format": "int32"
+          },
+          "dueDateFilter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExportDueDateFilterDto"
+              }
+            ],
+            "description": "Specify the due date filter for the export. If left null, no due date filter will be applied",
+            "nullable": true
+          },
+          "priorityFilter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExportPriorityFilterDto"
+              }
+            ],
+            "description": "Specify the priority filter for the export. If left null, no priority filter will be applied",
+            "nullable": true
+          },
+          "progressFilter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskExportProgressFilterDto"
+              }
+            ],
+            "description": "Specify the progress filter for the export. If left null, no progress filter will be applied",
+            "nullable": true
+          },
+          "assignees": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "A list of resourceIds to filter the risks by assignees. If left null or empty this will be ignored",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "A list of tagIds to filter the risks by tags. If left null or empty this will be ignored",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Export Settings for Risk Export"
+      },
+      "State": {
+        "enum": [
+          "NotStarted",
+          "InProgress",
+          "Success",
+          "Discard",
+          "Fail"
+        ],
+        "type": "string",
+        "description": "The state of the ProjectChange"
+      },
+      "StringObjectDictionaryAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TagCreateDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this Tag."
+          },
+          "color": {
+            "type": "string",
+            "description": "The color that will be used to represent this Tag visually.  This color\r\nis automatically chosen by the application when a user creates a Tag.\r\n            \r\nYou can choose specify any color that can be represented using HTML RGB\r\nsyntax such as `#0088FF`, in the format `RRGGBB`.  You may not use names\r\nfor colors.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color."
+      },
+      "TagDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Tag.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Tag.",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The color that will be used to represent this Tag visually.  This color\r\nis automatically chosen by the application when a user creates a Tag.\r\n            \r\nYou can choose specify any color that can be represented using HTML RGB\r\nsyntax such as `#0088FF`, in the format `RRGGBB`.  You may not use names\r\nfor colors.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color."
+      },
+      "TagDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TagDto"
+              }
+            ],
+            "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TagDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TagUpdateDto": {
+        "type": "object",
+        "properties": {
+          "color": {
+            "type": "string",
+            "description": "The color that will be used to represent this Tag visually.  This color\r\nis automatically chosen by the application when a user creates a Tag.\r\n            \r\nYou can choose specify any color that can be represented using HTML RGB\r\nsyntax such as `#0088FF`, in the format `RRGGBB`.  You may not use names\r\nfor colors.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Tag is a named categorization you can use to distinguish objects from each other.\r\nTags each have a unique identifier, a name, and a color."
+      },
+      "TaskAssigneeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskAssignee",
+            "format": "uuid"
+          },
+          "initials": {
+            "type": "string",
+            "description": "A shortened set of initials to use when representing this TaskAssignee visually\r\nin small areas.  The initials may be used in small icons or other overlays.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this TaskAssignee",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A more complete description of the TaskAssignee.",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "True if this TaskAssignee is currently active with the Project."
+          },
+          "color": {
+            "type": "string",
+            "description": "The color that will be used to represent this TaskAssignee visually.\r\n            \r\nYou can choose specify any color that can be represented using HTML RGB\r\nsyntax such as `#0088FF`, in the format `RRGGBB`.  You may not use names\r\nfor colors.",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first or given name of this TaskAssignee.\r\n            \r\nFor personnel TaskAssignees only.",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last or family name of this TaskAssignee.\r\n            \r\nFor personnel TaskAssignees only.",
+            "nullable": true
+          },
+          "shortName": {
+            "type": "string",
+            "description": "A shortened version of the name of this TaskAssignee.  This is used in areas\r\nwhere the Initials are too short but the full name is too long.",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "description": "A link to an Avatar for this TaskAssignee.  Avatars are small images or representations\r\nthat can be used to visually identify this TaskAssignee at a glance.",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address for the resource. It can be empty if the resource does not have a login.",
+            "nullable": true
+          },
+          "allocatedEffort": {
+            "type": "integer",
+            "description": "The allocated effort (in minutes) for this Task and Assignee.",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskAssignee is the person to whom a Task is assigned.  A single Task\r\ncan be assigned to multiple TaskAssignees."
+      },
+      "TaskCreateDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The common name of this Task."
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the work to be performed in this Task.",
+            "nullable": true
+          },
+          "percentComplete": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The numerical percentage, from 0-100, representing the percentage completion\r\nfor this Task.  Any numbers below zero or above 100 will be clamped to the\r\nminimum or maximum value.\r\n            \r\nThis value can be edited manually in the Gantt chart view of the application,\r\nor can be selected on the Task Detail page within the Kanban board.",
+            "format": "int32",
+            "nullable": true
+          },
+          "statusId": {
+            "type": "string",
+            "description": "The unique identifier of the TaskStatus for this Task",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priorityId": {
+            "type": "integer",
+            "description": "A numerical value representing the Priority of this Task",
+            "format": "int32",
+            "nullable": true
+          },
+          "assignees": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "A list of unique identifiers of TaskAssignees to be assigned to this Task",
+            "nullable": true
+          },
+          "plannedStartDate": {
+            "type": "string",
+            "description": "The date when work on this Task is planned to begin.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedFinishDate": {
+            "type": "string",
+            "description": "The date when work on this Task is expected to complete.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedDuration": {
+            "maximum": 6570000,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The planned duration (in minutes) for this Task.  Cannot be negative.",
+            "format": "int32",
+            "default": null,
+            "nullable": true
+          },
+          "plannedEffort": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The planned effort (in minutes) for this Task.  Cannot be negative.",
+            "format": "int32",
+            "default": null,
+            "nullable": true
+          },
+          "plannedCost": {
+            "minimum": 0,
+            "type": "number",
+            "description": "The planned cost for this Task.  Cannot be negative.",
+            "format": "double",
+            "default": null,
+            "nullable": true
+          },
+          "actualStartDate": {
+            "type": "string",
+            "description": "The date when work on this Task actually started, if known.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualCost": {
+            "minimum": 0,
+            "type": "number",
+            "description": "The actual cost of this Task to date, if known.",
+            "format": "double",
+            "default": null,
+            "nullable": true
+          },
+          "theme": {
+            "type": "string",
+            "description": "Color theme definition for this task.\r\n            \r\neg. Blue, Brown, DarkBlue, DarkGrey, Gold, Green, Grey, LightBrown, LightGreen,\r\nLightGrey, LightPurple, LightYellow, Magenta, Mauve, Navy, Orange, Purple, Red.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+      },
+      "TaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Task.",
+            "format": "uuid"
+          },
+          "project": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskProjectDto"
+              }
+            ],
+            "description": "The Project to which this Task belongs.",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskTagDto"
+            },
+            "description": "The TaskTags that apply to this Task.",
+            "nullable": true
+          },
+          "projectId": {
+            "type": "string",
+            "description": "The unique identifier of the Project to which this Task belongs.",
+            "format": "uuid"
+          },
+          "assignees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskAssigneeDto"
+            },
+            "description": "The list of assignees who are to work on this Task, if any.",
+            "nullable": true
+          },
+          "todos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskTodoDto"
+            },
+            "description": "A list of TaskTodo items, which are sub-tasks within this Task.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short ID that can be used to refer to this Task.  This short ID is\r\nguaranteed to be unique within your Workspace.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Task.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the work to be performed in this Task.",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskStatusDto"
+              }
+            ],
+            "description": "The TaskStatus assigned to this Task.",
+            "nullable": true
+          },
+          "plannedStartDate": {
+            "type": "string",
+            "description": "The date when work on this Task is planned to begin.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date"
+          },
+          "plannedFinishDate": {
+            "type": "string",
+            "description": "The date when work on this Task is expected to complete.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualStartDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work began on the Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualFinishDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work was completed on this Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualEffort": {
+            "type": "integer",
+            "description": "The actual effort (in minutes) for this Task.",
+            "format": "int32",
+            "nullable": true
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this Task was most recently modified.",
+            "format": "date-time"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this Task was created.",
+            "format": "date-time"
+          },
+          "percentComplete": {
+            "type": "integer",
+            "description": "The numerical percentage, from 0-100, representing the percentage completion\r\nfor this Task.  Any numbers below zero or above 100 will be clamped to the\r\nminimum or maximum value.\r\n            \r\nThis value can be edited manually in the Gantt chart view of the application,\r\nor can be selected on the Task Detail page within the Kanban board.",
+            "format": "int32"
+          },
+          "isSummary": {
+            "type": "boolean",
+            "description": "True if this Task is the parent of multiple Tasks underneath it.  A parent Task\r\nis a \"rolled-up\" view of multiple children that allows you to view a section of\r\nwork at a glance.\r\n            \r\nYou can create a summary Task in the Gantt chart view of the application by\r\nadding child tasks underneath a parent Task."
+          },
+          "priorityId": {
+            "type": "integer",
+            "description": "Return the priority of a task",
+            "format": "int32",
+            "nullable": true
+          },
+          "wbs": {
+            "type": "string",
+            "description": "The WBS (Work Breakdown Structure) number for this task within the Gantt chart hierarchy.  See [What\r\nIs a Work Breakdown Structure (WBS)?](https://www.projectmanager.com/guides/work-breakdown-structure)\r\non Project Manager for more information. The WBS number is an outline number in the form `#.#.#.#`\r\nwhich indicates how tasks are organized and sorted.\r\n            \r\nThe WBS value is only available to users at certain edition levels.  This value can only be changed\r\nif you are a Project Editor.",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The hexadecimal RRGGBB Task Color as set in the Gantt.  This value is read-only; to set this value,\r\nchange the `Theme` field.",
+            "nullable": true
+          },
+          "theme": {
+            "type": "string",
+            "description": "Color theme definition for this Task.\r\n            \r\neg. Blue, Brown, DarkBlue, DarkGrey, Gold, Green, Grey, LightBrown, LightGreen,\r\nLightGrey, LightPurple, LightYellow, Magenta, Mauve, Navy, Orange, Purple, Red.",
+            "nullable": true
+          },
+          "actualCost": {
+            "type": "number",
+            "description": "The actual cost of this Task to date, if known.",
+            "format": "double",
+            "nullable": true
+          },
+          "actualResourceCost": {
+            "type": "number",
+            "description": "The actual resource cost of this Task",
+            "format": "double",
+            "nullable": true
+          },
+          "plannedCost": {
+            "type": "number",
+            "description": "The planned cost for this Task.  Cannot be negative.",
+            "format": "double",
+            "nullable": true
+          },
+          "plannedResourceCost": {
+            "type": "number",
+            "description": "The planned resource cost of this Task",
+            "format": "double",
+            "nullable": true
+          },
+          "plannedDuration": {
+            "type": "integer",
+            "description": "The planned duration (in minutes) for this Task.",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedEffort": {
+            "type": "integer",
+            "description": "The planned effort (in minutes) for this Task.",
+            "format": "int32",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskFieldValueDto"
+            },
+            "description": "Obsolete - use FieldValues instead",
+            "nullable": true,
+            "deprecated": true
+          },
+          "fieldValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskFieldValueDto"
+            },
+            "description": "Task fields array with values",
+            "nullable": true
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskFileDto"
+            },
+            "description": "The list of files associated with this Task, if any.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+      },
+      "TaskDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskDto"
+              }
+            ],
+            "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskFieldDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskField",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this TaskField",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this TaskField.  Valid types are the following:\r\n* Text\r\n* Number\r\n* Date\r\n* Checkbox\r\n* Currency\r\n* Dropdown\r\n            \r\nAttempting to create a field with any Type other than these will\r\nreturn an error.\r\n            \r\nFor Dropdown TaskFields, specify the list of choices in the `Options`\r\nfield.",
+            "nullable": true
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of options for use of this TaskField.  This is only valid if\r\nthe `Type` value is set to `Dropdown`.\r\n            \r\nWhen a custom TaskField of type `DropDown` is shown to a user in the\r\napplication, they will be able to choose one of the `Options` in this\r\nlist.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The short Id of this TaskField - human readable identity",
+            "nullable": true
+          },
+          "project": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskFieldProjectDto"
+              }
+            ],
+            "description": "The Project to which this TaskField belongs.",
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was created.",
+            "format": "date-time"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was last modified.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskField is a custom field defined within your Workspace for a specific Project.  You can\r\ndefine TaskFields for any integration purpose that is important to your business.  Each\r\nTaskField has a data type as well as options in how it is handled.  TaskFields can be edited\r\nfor each Task inside this Project."
+      },
+      "TaskFieldDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskFieldDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskFieldProjectDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Project.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The ShortId of this Project.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Project.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "The TaskFieldProject is a summary of the Project that this TaskField relates to."
+      },
+      "TaskFieldValueDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskField.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The unique Short Id of this TaskField.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Project Field.",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this TaskField.  Valid types are the following:\r\n* Text\r\n* Number\r\n* Date\r\n* Checkbox\r\n* Currency\r\n* Dropdown",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "description": "The value currently set for this TaskFieldValue.",
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was created.",
+            "format": "date-time"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this TaskField was last modified.",
+            "format": "date-time"
+          },
+          "task": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskFieldValueTaskDto"
+              }
+            ],
+            "description": "The Task to which this Value belongs.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A model that contains the value for a TaskField."
+      },
+      "TaskFieldValueDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskFieldValueDto"
+              }
+            ],
+            "description": "A model that contains the value for a TaskField.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskFieldValueDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskFieldValueDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskFieldValueTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Task.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The unique Short Id of this Task.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Task.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "The TaskFieldTask is a summary of the Task that this TaskFieldValue relates to."
+      },
+      "TaskFileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this file",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The url of the file which can be used for downloading",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a file associated with a Task in project manager"
+      },
+      "TaskMetadataSearchDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Task ID",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Project ID",
+            "format": "uuid"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Customer or system metadata",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Task Metadata Search DTO"
+      },
+      "TaskMetadataSearchDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskMetadataSearchDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskMetadataUpdateDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Customer or system metadata",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Task Metadata DTO"
+      },
+      "TaskPriorityDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier of this TaskPriority.",
+            "format": "int32",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this TaskPriority.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskPriority is a named priority level used by your business to determine how to decide\r\nwhich Tasks are the most important.  You can name your TaskPriority levels anything you like\r\nand you can reorganize the order of the TaskPriority levels at any time."
+      },
+      "TaskPriorityDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskPriorityDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskProjectDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Project.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "The ShortId of this Project.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Project.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project."
+      },
+      "TaskStatusCreateDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskStatus.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this TaskStatus."
+          },
+          "order": {
+            "type": "integer",
+            "description": "A numerical value that can be used to sort TaskStatus values according to the\r\nneeds of your business.",
+            "format": "int32",
+            "nullable": true
+          },
+          "isDone": {
+            "type": "boolean",
+            "description": "A numerical value that can be used to sort TaskStatus values according to the\r\nneeds of your business.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done."
+      },
+      "TaskStatusDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskStatus.",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "The unique identifier of the Project to which this TaskStatus belongs.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this TaskStatus.",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "description": "A numerical value that can be used to sort TaskStatus values according to the\r\nneeds of your business.",
+            "format": "int32"
+          },
+          "isDone": {
+            "type": "boolean",
+            "description": "True if a Task in this TaskStatus is considered done."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done."
+      },
+      "TaskStatusDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskStatusDto"
+              }
+            ],
+            "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskStatusDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskStatusDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TaskStatusUpdateDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "^((?!00000000-0000-0000-0000-000000000000).)*$",
+            "type": "string",
+            "description": "The unique identifier of this TaskStatus.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this TaskStatus.",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "description": "A numerical value that can be used to sort TaskStatus values according to the\r\nneeds of your business.",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskStatus is a named status level used by your business to determine how to measure the\r\nprogress of Tasks.  You can define your own named status levels that are appropriate for\r\nyour business and determine which status levels are considered done."
+      },
+      "TaskTagDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskTag.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this TaskTag.",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The color that will be used to represent this Tag visually.  This color\r\nis automatically chosen by the application when a user creates a Tag.\r\n            \r\nYou can choose specify any color that can be represented using HTML RGB\r\nsyntax such as `#0088FF`, in the format `RRGGBB`.  You may not use names\r\nfor colors.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskTag is a connection between a Task and a Tag.  Each Task can have zero, one or many\r\nTaskTags associated with it.  TaskTags can be assigned and removed from the Task to help you\r\nclassify your Tasks and prioritize work."
+      },
+      "TaskTodoDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this TaskTodo.",
+            "format": "uuid"
+          },
+          "text": {
+            "type": "string",
+            "description": "The full description of this TaskTodo.",
+            "nullable": true
+          },
+          "complete": {
+            "type": "boolean",
+            "description": "True if this TaskTodo is complete."
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this object was created.",
+            "format": "date-time"
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this object was last modified.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A TaskTodo is a sub-task that represents a unit of work on the Task.  You can use\r\nTaskTodo to represent individual items for a larger piece of work."
+      },
+      "TaskUpdateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The common name of this Task.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the work to be performed in this Task.",
+            "nullable": true
+          },
+          "percentComplete": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The numerical percentage, from 0-100, representing the percentage completion\r\nfor this Task.  Any numbers below zero or above 100 will be clamped to the\r\nminimum or maximum value.\r\n            \r\nThis value can be edited manually in the Gantt chart view of the application,\r\nor can be selected on the Task Detail page within the Kanban board.",
+            "format": "int32",
+            "nullable": true
+          },
+          "statusId": {
+            "type": "string",
+            "description": "The TaskStatus assigned to this Task.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priorityId": {
+            "type": "integer",
+            "description": "The unique identifier of the TaskPriority",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedStartDate": {
+            "type": "string",
+            "description": "The date when work on this Task is planned to begin.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedFinishDate": {
+            "type": "string",
+            "description": "The date when work on this Task is expected to complete.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "plannedDuration": {
+            "maximum": 6570000,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The planned duration (in minutes) for this Task.  Cannot be negative.",
+            "format": "int32",
+            "default": null,
+            "nullable": true
+          },
+          "plannedEffort": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer",
+            "description": "The planned effort (in minutes) for this Task.  Cannot be negative.",
+            "format": "int32",
+            "default": null,
+            "nullable": true
+          },
+          "plannedCost": {
+            "minimum": 0,
+            "type": "number",
+            "description": "The planned cost for this Task.  Cannot be negative.",
+            "format": "double",
+            "default": null,
+            "nullable": true
+          },
+          "actualStartDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work began on the Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualFinishDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work was completed on the Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date",
+            "nullable": true
+          },
+          "actualCost": {
+            "minimum": 0,
+            "type": "number",
+            "description": "If set, this represents the actual tracked cost for this Task.",
+            "format": "double",
+            "nullable": true
+          },
+          "theme": {
+            "type": "string",
+            "description": "Color theme definition for this task.\r\n            \r\neg. Blue, Brown, DarkBlue, DarkGrey, Gold, Green, Grey, LightBrown, LightGreen,\r\nLightGrey, LightPurple, LightYellow, Magenta, Mauve, Navy, Orange, Purple, Red.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+      },
+      "TimeSheetProjectDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the Project.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the Project.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the Project",
+            "nullable": true
+          },
+          "shortCode": {
+            "type": "string",
+            "description": "A shortened name that will be used when reporting on Projects.  This short\r\nname can be edited in the Project Settings page within the application\r\nand can be any text you wish.",
+            "nullable": true
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short identifier that uniquely identifies this Project within your Workspace\r\nusing a single letter followed by a number.  This code can be used for APIs\r\nthat accept Project unique identifiers.\r\n            \r\nYou can observe the short ID within the application by observing the URL of\r\nthe page you visit when you click on this project.  The page's URL will appear\r\nin the form `https://pm.app.projectmanager.com/project/board/D16` - in this\r\nexample, the `ShortId` is `D16`.\r\n            \r\nThis code is automatically assigned for you and cannot be changed.",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The earliest planned or actual start date of tasks on the project.\r\n            \r\nThis field is calculated automatically and cannot be changed.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "description": "The latest planned or actual finish date of tasks on the project.\r\n            \r\nThis field is calculated automatically and cannot be changed.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "The target planned completion date for this Project, or null if one has\r\nnot been selected.  This value can be updated in the Project Settings\r\npage or the Portfolio Project page within the application.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "budget": {
+            "type": "number",
+            "description": "The proposed budget for this Project.",
+            "format": "double",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "The default hourly rate for work on this Project.  This rate will be used\r\nif an assignee working on this Project does not have an hourly rate configured\r\nin their profile.",
+            "format": "double",
+            "nullable": true
+          },
+          "statusUpdate": {
+            "type": "string",
+            "description": "Contains an optional status update for Projects that can be used to summarize\r\nthe status of multiple Projects at a glance.\r\n            \r\nYou can edit the StatusUpdate field on the Portfolio page of the application.",
+            "nullable": true
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when the Project was most recently modified.",
+            "format": "date-time"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when the Project was created.",
+            "format": "date-time"
+          },
+          "isTemplate": {
+            "type": "boolean",
+            "description": "True if this Project is a template that will be reused as a framework\r\nfor future Projects."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks\r\nrepresent individual items of work that team members must complete.  The sum total of Tasks\r\nwithin a Project represents the work to be completed for that Project."
+      },
+      "TimesheetAdminTypeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "admin task id",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "admin task name",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents admin task to track time"
+      },
+      "TimesheetAdminTypeDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimesheetAdminTypeDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TimesheetCreateRequestDto": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "Time entry date",
+            "format": "date"
+          },
+          "hours": {
+            "type": "number",
+            "description": "Reported hours",
+            "format": "double"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "Task id that time reported to",
+            "format": "uuid",
+            "nullable": true
+          },
+          "adminTypeId": {
+            "type": "string",
+            "description": "Admin task id that time reported to",
+            "format": "uuid",
+            "nullable": true
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "Resource id that time reported to",
+            "format": "uuid",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Notes",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Payload to create time entry"
+      },
+      "TimesheetDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier of a timesheet data entry",
+            "format": "uuid"
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "The unique identifier of the resource who is preparing this Timesheet.  You can filter on this value to measure\r\nthe total work performed by this specific Resource.",
+            "format": "uuid"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "The unique identifier of the task worked on for this Timesheet.  You can filter on this value to measure the\r\ntotal work performed against a specific Task.",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "The unique identifier of the project worked on for this Timesheet.  You can filter on this value to measure the\r\ntotal work performed against a specific Project.",
+            "format": "uuid"
+          },
+          "date": {
+            "type": "string",
+            "description": "The date of this time entry record.  You can filter on this value to obtain Timesheet data for a specific date\r\nrange.",
+            "format": "date-time"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Notes associated with this Timesheet, if any",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean",
+            "description": "True if this Timesheet was approved by a person with the role of a Timesheet approver"
+          },
+          "hours": {
+            "type": "number",
+            "description": "Total Hours spent on this Task by this Resource on this specific Date",
+            "format": "double"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "description": "Date and time (in UTC) that this timesheet entry was last modified.",
+            "format": "date-time"
+          },
+          "task": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimesheetTaskDto"
+              }
+            ],
+            "description": "The task associated with this timesheet entry",
+            "nullable": true
+          },
+          "project": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimeSheetProjectDto"
+              }
+            ],
+            "description": "The project associated with this timesheet entry",
+            "nullable": true
+          },
+          "resource": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimesheetResourceDto"
+              }
+            ],
+            "description": "The resource associated with this timesheet entry",
+            "nullable": true
+          },
+          "adminType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimesheetAdminTypeDto"
+              }
+            ],
+            "description": "The administration type associated with this timesheet entry",
+            "nullable": true
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimesheetFileDto"
+            },
+            "description": "The list of files associated with this Timesheet, if any.\r\n            \r\nThis field will be present when you fetch a single object.\r\nWhen you query for multiple objects, this field is not included in results by default.\r\nTo expand this field, specify the name of this field in the `$expand` parameter.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Timesheet entry is a single record that contains information about time spent by a person on a task.  Each\r\nTimesheet entry object contains information about one task/day/person combination.  A fully completed Timesheet\r\nwill often contain multiple records for the same date range which must be combined to produce a finished\r\nTimesheet."
+      },
+      "TimesheetDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimesheetDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TimesheetFileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier for this file",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The url of the file which can be used for downloading",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TimesheetResourceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Resource.",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the person Resource.\r\n            \r\nApplies to personnel Resources only.",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address of this Resource.",
+            "nullable": true
+          },
+          "hourlyRate": {
+            "type": "number",
+            "description": "The default hourly rate of the resource.",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Resource represents a person, material, or tool that is used within your Projects.\r\nWhen you attach a Resources to more than one Task, the software will schedule the usage\r\nof your Resource so that it is not allocated to more than one Task at the same time.\r\nThe users in your Workspace are also considered Resources.  To invite a new User to your\r\nWorkspace, create a new Resource for that user."
+      },
+      "TimesheetResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "TimesheetId",
+            "format": "uuid"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "associated task id",
+            "format": "uuid",
+            "nullable": true
+          },
+          "projectId": {
+            "type": "string",
+            "description": "associated project id",
+            "format": "uuid",
+            "nullable": true
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "resource id time entry entered",
+            "format": "uuid",
+            "nullable": true
+          },
+          "timesheetAdminTypeId": {
+            "type": "string",
+            "description": "admin task id",
+            "format": "uuid",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "description": "Date of time entry",
+            "format": "date-time"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Notes",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean",
+            "description": "Shows if timesheet approved"
+          },
+          "hours": {
+            "type": "number",
+            "description": "Total Hours",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Time entry representation"
+      },
+      "TimesheetResponseDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimesheetResponseDto"
+              }
+            ],
+            "description": "Time entry representation",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "TimesheetTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Task.",
+            "format": "uuid"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "The unique identifier of the Project to which this Task belongs.",
+            "format": "uuid"
+          },
+          "shortId": {
+            "type": "string",
+            "description": "A short ID that can be used to refer to this Task.  This short ID is\r\nguaranteed to be unique within your Workspace.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The common name of this Task.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the work to be performed in this Task.",
+            "nullable": true
+          },
+          "plannedStartDate": {
+            "type": "string",
+            "description": "The date when work on this Task is planned to begin.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "plannedFinishDate": {
+            "type": "string",
+            "description": "The date when work on this Task is expected to complete.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "actualStartDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work began on the Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "actualFinishDate": {
+            "type": "string",
+            "description": "If set, this is the actual date when work was completed on this Task.\r\n            \r\nThis value contains only the date in year-month-day format.  For display, this\r\ndate will always be shown as this same year-month-day regardless of time zone.\r\nFor reporting purposes, this date is calculated against the official time zone\r\nof the Workspace.\r\n            \r\nFor example: A Task has a planned completion date of July 5, 2023 in a Workspace\r\nthat has a time zone of US Pacific Time (GMT-7 or GMT-8, depending on daylight\r\nsavings time).  This project is considered overdue on 12:01 AM July 6th 2023 in\r\nUS Pacific time.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "modifyDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this Task was most recently modified.",
+            "format": "date-time"
+          },
+          "createDate": {
+            "type": "string",
+            "description": "The timestamp in UTC when this Task was created.",
+            "format": "date-time"
+          },
+          "percentComplete": {
+            "type": "integer",
+            "description": "The numerical percentage, from 0-100, representing the percentage completion\r\nfor this Task.  Any numbers below zero or above 100 will be clamped to the\r\nminimum or maximum value.\r\n            \r\nThis value can be edited manually in the Gantt chart view of the application,\r\nor can be selected on the Task Detail page within the Kanban board.",
+            "format": "int32"
+          },
+          "isSummary": {
+            "type": "boolean",
+            "description": "True if this Task is the parent of multiple Tasks underneath it.  A parent Task\r\nis a \"rolled-up\" view of multiple children that allows you to view a section of\r\nwork at a glance.\r\n            \r\nYou can create a summary Task in the Gantt chart view of the application by\r\nadding child tasks underneath a parent Task."
+          },
+          "priorityId": {
+            "type": "integer",
+            "description": "Return the priority of a task",
+            "format": "int32",
+            "nullable": true
+          },
+          "wbs": {
+            "type": "string",
+            "description": "The WBS (Work Breakdown Structure) number for this task within the Gantt chart hierarchy.  See [What\r\nIs a Work Breakdown Structure (WBS)?](https://www.projectmanager.com/guides/work-breakdown-structure)\r\non Project Manager for more information. The WBS number is an outline number in the form `#.#.#.#`\r\nwhich indicates how tasks are organized and sorted.\r\n            \r\nThe WBS value is only available to users at certain edition levels.  This value can only be changed\r\nif you are a Project Editor.",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "Task Color as set in the Gantt",
+            "nullable": true
+          },
+          "actualCost": {
+            "type": "number",
+            "description": "The actual cost of this Task, if known.",
+            "format": "double",
+            "nullable": true
+          },
+          "actualResourceCost": {
+            "type": "number",
+            "description": "The actual resource cost of this Task",
+            "format": "double",
+            "nullable": true
+          },
+          "actualEffort": {
+            "type": "integer",
+            "description": "The actual effort (in minutes) of this task, if known.",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedCost": {
+            "type": "number",
+            "description": "The planned cost for this Task.  Cannot be negative.",
+            "format": "double",
+            "nullable": true
+          },
+          "plannedResourceCost": {
+            "type": "number",
+            "description": "The planned resource cost of this Task",
+            "format": "double",
+            "nullable": true
+          },
+          "plannedEffort": {
+            "type": "integer",
+            "description": "The planned effort (in minutes) of this task, if known.",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Task is an individual element of work that must be performed to complete a Project.  A\r\nTask can have one or more Resources assigned to it.  Tasks can be linked to other Tasks to\r\nindicate whether they have a dependency or a connection."
+      },
+      "TimesheetUpdateRequestDto": {
+        "type": "object",
+        "properties": {
+          "hours": {
+            "type": "number",
+            "description": "Reported hours",
+            "format": "double",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Notes",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Payload to update time entry"
+      },
+      "UpdateProjectFieldValueDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The new value to be set for this ProjectField.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A model that contains a new value to be set for a ProjectField."
+      },
+      "UpdateRequestDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name for the File.",
+            "nullable": true
+          },
+          "taskId": {
+            "type": "string",
+            "description": "To assign this File to a Task, specify the TaskId here.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "folderId": {
+            "type": "string",
+            "description": "To move this File to a new Folder, specify the Folder's unique identifier here.",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents an update request for a File within ProjectManager.\r\n            \r\nProjectManager allows you to store Files connected to other elements of your Workspace\r\nsuch as a Project or a Discussion.  When you upload a File, please allow a few moments\r\nfor the File to be processed and verified.  ProjectManager may reject File uploads that\r\ncontain problems such as malware. Once a File has completed the upload the process, you\r\nmay retrieve it using the DownloadFile API."
+      },
+      "UpdateResourceSkillDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this Skill."
+          }
+        },
+        "additionalProperties": false,
+        "description": "This is a skill that can be allocated to a resource."
+      },
+      "UpdateResourceTeamDto": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of this Resource Team."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A resource can update a team."
+      },
+      "UpdateTaskFieldValueDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The new value to be set for this TaskField.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A model that contains a new value to be set for a TaskField."
+      },
+      "UserError": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserRoleDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this UserRole.",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "The friendly name of this UserRole.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A UserRole is a name for a privilege level granted to a specific User.  The 'Global Admin'\r\nUserRole is granted to the owner of the Workspace, and this UserRole cannot be changed.\r\nYou can choose which UserRole applies to a User within your Workspace."
+      },
+      "UserRoleDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserRoleDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "WorkSpaceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this Workspace.",
+            "format": "uuid"
+          },
+          "company": {
+            "type": "string",
+            "description": "The name of this Workspace.",
+            "nullable": true
+          },
+          "customProductDomain": {
+            "type": "string",
+            "description": "The unique DNS domain of this Workspace.",
+            "nullable": true
+          },
+          "customerId": {
+            "type": "string",
+            "description": "TODO - What is this value?",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isOwner": {
+            "type": "boolean",
+            "description": "This value is set to true if the user who retrieves this Workspace object via an API call is \r\nthe owner of this Workspace."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "The organization code used for authentication systems for this Workspace.",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The RGB color in the format `#RRGGBB` for this Workspace.",
+            "nullable": true
+          },
+          "roleName": {
+            "type": "string",
+            "description": "The role of the current user within this Workspace.",
+            "nullable": true
+          },
+          "registerDate": {
+            "type": "string",
+            "description": "The timestamp when the Workspace was created.",
+            "format": "date-time"
+          },
+          "isInviteAccepted": {
+            "type": "boolean",
+            "description": "True if the user has accepted an invitation to this Workspace.",
+            "deprecated": true
+          },
+          "businessUserId": {
+            "type": "string",
+            "description": "The unique identifier of the BusinessUser that is the owner of this Workspace.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isPaid": {
+            "type": "boolean",
+            "description": "True if this Workspace has an active subscription; false if this is a free trial."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Workspace represents a single business subscription to the ProjectManager.com service.  You\r\ncan be a member of multiple Workspaces.  Each Workspace is completely separate from all other\r\nWorkspaces and a user cannot log in to multiple Workspaces at the same time."
+      },
+      "WorkSpaceDtoListAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkSpaceDto"
+            },
+            "description": "If the API call succeeded, this will contain the results.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      },
+      "WorkSpaceJoinDto": {
+        "type": "object",
+        "properties": {
+          "businessUserId": {
+            "type": "string",
+            "description": "The unique identifier of the BusinessUser to invite to this Workspace.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A Workspace represents a single business subscription to the ProjectManager.com service.  You\r\ncan be a member of multiple Workspaces.  Each Workspace is completely separate from all other\r\nWorkspaces and a user cannot log in to multiple Workspaces at the same time."
+      },
+      "WorkSpaceLinksDto": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The name of the project for this link.",
+            "nullable": true
+          },
+          "workSpaceApi": {
+            "type": "string",
+            "description": "This is the link to the api for this business.  Some endpoints may need this value.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A shortcut link within the currently logged in Workspace."
+      },
+      "WorkSpaceUserInfoDto": {
+        "type": "object",
+        "properties": {
+          "links": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkSpaceLinksDto"
+              }
+            ],
+            "description": "A collection of shortcut links for the currently logged in Workspace.",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "description": "The email address of the currently logged in user.",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique identity of the currently logged in user.",
+            "format": "uuid"
+          },
+          "fullName": {
+            "type": "string",
+            "description": "The full name of the currently logged in user.",
+            "nullable": true
+          },
+          "workSpaceName": {
+            "type": "string",
+            "description": "The name of the Workspace that the current user has logged onto.  For most companies, the workspace\r\nname will be the name of the business.",
+            "nullable": true
+          },
+          "roleName": {
+            "type": "string",
+            "description": "The user's role within the current Workspace.",
+            "nullable": true
+          },
+          "isGlobalAdmin": {
+            "type": "boolean",
+            "description": "True if this user is considered a global administrator of the current Workspace.",
+            "nullable": true
+          },
+          "isAccountAdministrator": {
+            "type": "boolean",
+            "description": "True if this user is considered an account administrator of the current Workspace.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Information about a currently logged in user.\r\n            \r\nYou can call the RetrieveMe API to gather information about the current user."
+      },
+      "WorkSpaceUserInfoDtoAstroResult": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AstroError"
+              }
+            ],
+            "description": "If the API call failed, this will contain information about the error that occurred.",
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean",
+            "description": "True if the API call succeeded; false otherwise.",
+            "readOnly": true
+          },
+          "hasError": {
+            "type": "boolean",
+            "description": "True if the API call failed.",
+            "readOnly": true
+          },
+          "statusCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpStatusCode"
+              }
+            ],
+            "description": "The HTTP code of the response."
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkSpaceUserInfoDto"
+              }
+            ],
+            "description": "Information about a currently logged in user.\r\n            \r\nYou can call the RetrieveMe API to gather information about the current user.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "An API result that contains different values depending on whether the API call succeeded or failed.\r\nIf the API call succeeded, the `Success` value will be true and you can use the `Data` element.\r\nIf the API call failed, `Success` will be false and the `Error` value will be non-null."
+      }
+    },
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://app.projectmanager.com/authorize",
+            "tokenUrl": "https://app.projectmanager.com/oauth/token",
+            "scopes": {
+              "read:all": "Access the API read operations",
+              "write:all": "Access the API write operations"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "oauth2": [
+        "read:all",
+        "write:all"
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.projectmanager.com"
+    }
+  ]
+}


### PR DESCRIPTION
It appears that with release 119 the POM.xml file got reverted.  Let's put it back to the way it was when I tested it, and we'll go ahead and update the SDK generator too.